### PR TITLE
fix: remove leftover spacing on right border of log viewport

### DIFF
--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -76,7 +76,7 @@ func (m model) logVisibleWidth() int {
 	totalWidth := max(1, m.width)
 	if m.screen == screenModeLogs {
 		pageContentWidth := m.logsPageContentWidth(totalWidth)
-		return max(1, pageContentWidth-4)
+		return max(1, pageContentWidth-2)
 	}
 	innerWidth := util.FrameContentWidth(totalWidth, m.styles.MainFrame)
 	return max(1, innerWidth-2)


### PR DESCRIPTION
Closes #34 