### PR TITLE
chore: flatten btable, consolidate resource types, extract palette

### DIFF
--- a/internal/core/format.go
+++ b/internal/core/format.go
@@ -1,6 +1,9 @@
 package core
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 func HumanBytes(size int64) string {
 	const unit = 1024
@@ -13,4 +16,59 @@ func HumanBytes(size int64) string {
 		exp++
 	}
 	return fmt.Sprintf("%.1f %ciB", float64(size)/float64(div), "KMGTPE"[exp])
+}
+
+func ContainerCPUValue(container ContainerRow, loadingIndicator string) string {
+	if container.CPUPercent < 0 {
+		if strings.EqualFold(container.State, "running") {
+			return metricsLoadingValue(loadingIndicator)
+		}
+		return "-"
+	}
+	if container.CPUPercent < 0.05 {
+		if strings.EqualFold(container.State, "running") {
+			return "0.0%"
+		}
+		return "-"
+	}
+	return fmt.Sprintf("%.1f%%", container.CPUPercent)
+}
+
+func ContainerMemoryTableValue(container ContainerRow, loadingIndicator string) string {
+	if container.MemoryUsage == "-" || strings.EqualFold(container.MemoryUsage, "loading") {
+		if strings.EqualFold(container.State, "running") {
+			return metricsLoadingValue(loadingIndicator)
+		}
+		return "-"
+	}
+	return fmt.Sprintf("%s", container.MemoryUsage)
+}
+
+func metricsLoadingValue(loadingIndicator string) string {
+	if strings.TrimSpace(loadingIndicator) == "" {
+		return "-"
+	}
+	return loadingIndicator
+}
+
+func ResourceLabel(rt ResourceType) string {
+	switch rt {
+	case ResourceContainer:
+		return "Containers"
+	case ResourceImage:
+		return "Images"
+	case ResourceNetwork:
+		return "Networks"
+	case ResourceVolume:
+		return "Volumes"
+	default:
+		return "Containers"
+	}
+}
+
+func ContainerStateText(container ContainerRow) string {
+	if container.Healthy && container.State == "running" {
+		return "● healthy"
+	}
+	return "● " + container.State
 }

--- a/internal/core/format_test.go
+++ b/internal/core/format_test.go
@@ -2,26 +2,37 @@ package core
 
 import "testing"
 
-func TestHumanBytes(t *testing.T) {
-	tests := []struct {
-		name string
-		size int64
-		want string
-	}{
-		{name: "negative", size: -1, want: "-1 B"},
-		{name: "bytes", size: 0, want: "0 B"},
-		{name: "under kibibyte", size: 1023, want: "1023 B"},
-		{name: "one kibibyte", size: 1024, want: "1.0 KiB"},
-		{name: "fractional kibibyte", size: 1536, want: "1.5 KiB"},
-		{name: "one mebibyte", size: 1024 * 1024, want: "1.0 MiB"},
-		{name: "one gibibyte", size: 1024 * 1024 * 1024, want: "1.0 GiB"},
+func TestContainerCPUValue_RunningNeverDash(t *testing.T) {
+	loading := ContainerCPUValue(ContainerRow{State: "running", CPUPercent: -1}, "⠋")
+	if loading != "⠋" {
+		t.Fatalf("running loading cpu = %q, want spinner icon", loading)
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := HumanBytes(tt.size); got != tt.want {
-				t.Fatalf("HumanBytes(%d) = %q, want %q", tt.size, got, tt.want)
-			}
-		})
+	idle := ContainerCPUValue(ContainerRow{State: "running", CPUPercent: 0}, "⠋")
+	if idle != "0.0%" {
+		t.Fatalf("running zero cpu = %q, want 0.0%%", idle)
+	}
+
+	afterInitial := ContainerCPUValue(ContainerRow{State: "running", CPUPercent: -1}, "")
+	if afterInitial != "-" {
+		t.Fatalf("running loading cpu with no indicator = %q, want -", afterInitial)
+	}
+}
+
+func TestContainerMemoryTableValue_OmitsLimit(t *testing.T) {
+	running := ContainerRow{State: "running", MemoryUsage: "128 MiB", MemoryLimit: "2 GiB", MemoryPercent: 6.25}
+	got := ContainerMemoryTableValue(running, "⠋")
+	if got != "128 MiB" {
+		t.Fatalf("table memory value = %q, want %q", got, "128 MiB (6.2%)")
+	}
+
+	loading := ContainerMemoryTableValue(ContainerRow{State: "running", MemoryUsage: "-"}, "⠋")
+	if loading != "⠋" {
+		t.Fatalf("running placeholder memory value = %q, want spinner icon", loading)
+	}
+
+	afterInitial := ContainerMemoryTableValue(ContainerRow{State: "running", MemoryUsage: "-"}, "")
+	if afterInitial != "-" {
+		t.Fatalf("running placeholder memory value with no indicator = %q, want -", afterInitial)
 	}
 }

--- a/internal/tui/helpers.go
+++ b/internal/tui/helpers.go
@@ -1,0 +1,41 @@
+package tui
+
+import (
+	"easydocker/internal/tui/shared"
+)
+
+func (m model) shouldAnimateLogsLoadingIndicator() bool {
+	return (m.screen == shared.Logs || m.screen == shared.Inspect) && (m.viewer.InitialLoad || m.viewer.HistoryLoad)
+}
+
+func (m model) shouldAnimateMetricsLoadingIndicator() bool {
+	return !m.metricsLoaded && m.loadingStage != loadStageIdle
+}
+
+func (m model) shouldReloadSnapshotOnTick() bool {
+	return m.loadingStage == loadStageIdle
+}
+
+func (m model) shouldLoadHistoryOnTick() bool {
+	return m.screen == shared.Logs &&
+		m.viewer.ContainerID != "" &&
+		m.viewer.Viewport.AtTop() &&
+		!m.viewer.InitialLoad &&
+		!m.viewer.HistoryLoad &&
+		!m.viewer.HistoryDone
+}
+
+func (m model) shouldPollLogsOnTick() bool {
+	return m.screen == shared.Logs &&
+		m.viewer.ContainerID != "" &&
+		!m.viewer.Viewport.AtTop() &&
+		!m.viewer.InitialLoad &&
+		!m.viewer.HistoryLoad
+}
+
+func (m model) logsPollTail() int {
+	if m.viewer.TailLines <= 0 {
+		return InitialTail
+	}
+	return m.viewer.TailLines
+}

--- a/internal/tui/integration_test.go
+++ b/internal/tui/integration_test.go
@@ -444,7 +444,8 @@ func TestIntegration_ContainersComposeRow_CollapsesAndExpands(t *testing.T) {
 			{FullID: "ctr-2", Name: "worker", ComposeProject: "shop", State: "running"},
 		},
 	}
-	*m = m.setupBrowseCallbacks()
+	*m = m.syncBrowseData()
+
 	if got := m.browse.ItemCountForTab(tabContainers); got != 1 {
 		t.Fatalf("collapsed compose list should show one row, got %d", got)
 	}
@@ -520,7 +521,7 @@ func TestIntegration_ContainersTabCount_UsesTotalContainersWhenComposeCollapsed(
 			{FullID: "ctr-2", Name: "worker", ComposeProject: "shop", State: "running"},
 		},
 	}
-	*m = m.setupBrowseCallbacks()
+	*m = m.syncBrowseData()
 
 	view := m.View().Content
 	if !strings.Contains(util.StripANSI(view), "Containers") {

--- a/internal/tui/keymap.go
+++ b/internal/tui/keymap.go
@@ -1,7 +1,10 @@
 package tui
 
 import (
+	"strings"
+
 	"easydocker/internal/tui/screens/browse"
+	"easydocker/internal/tui/screens/menu"
 	"easydocker/internal/tui/screens/viewer"
 	"easydocker/internal/tui/shared"
 	"easydocker/internal/tui/ui/tables"
@@ -30,7 +33,7 @@ func (m model) footerKeyMap() help.KeyMap {
 				containerState = c.State
 			}
 		}
-		return footerKeyMap{bindings: viewerKeys.ShortHelp(resourceTypeFromTab(m.browse.ActiveTab), contentType, containerState)}
+		return footerKeyMap{bindings: viewerKeys.ShortHelp(shared.TabToResourceType(m.browse.ActiveTab), contentType, containerState)}
 	}
 
 	browseKeys := browse.NewKeyMap()
@@ -69,14 +72,13 @@ func (m model) footerKeyMap() help.KeyMap {
 }
 
 func (m model) selectedContainerListRow() (tables.ContainerListRow, bool) {
-	rows := m.containerListRows()
+	rows := m.browse.Data.ContainerListRows
 	var zero tables.ContainerListRow
 	if len(rows) == 0 || m.browse.ContainerCursor < 0 || m.browse.ContainerCursor >= len(rows) {
 		return zero, false
 	}
 	return rows[m.browse.ContainerCursor], true
 }
-
 type footerKeyMap struct {
 	bindings []key.Binding
 }
@@ -89,17 +91,40 @@ func (m footerKeyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{m.bindings}
 }
 
-func resourceTypeFromTab(tab shared.Tab) viewer.ResourceType {
-	switch tab {
-	case tabContainers:
-		return viewer.ResourceTypeContainer
-	case tabImages:
-		return viewer.ResourceTypeImage
-	case tabNetworks:
-		return viewer.ResourceTypeNetwork
-	case tabVolumes:
-		return viewer.ResourceTypeVolume
-	default:
-		return viewer.ResourceTypeContainer
+func keyLabel(binding key.Binding) string {
+	return strings.TrimSpace(binding.Help().Key)
+}
+
+func joinKeyLabels(sep string, bindings ...key.Binding) string {
+	labels := make([]string, 0, len(bindings))
+	for _, binding := range bindings {
+		label := keyLabel(binding)
+		if label == "" {
+			continue
+		}
+		labels = append(labels, label)
 	}
+	return strings.Join(labels, sep)
+}
+
+func (m model) buildHelpCommands() []menu.HelpCommand {
+	browseKeys := browse.NewKeyMap()
+	viewerKeys := viewer.NewKeyMap()
+	menuKeys := menu.NewKeyMap()
+
+	return menu.BuildHelpCommands(menu.HelpKeyLabels{
+		MoveUpDown:   joinKeyLabels("/", browseKeys.MoveUp, browseKeys.MoveDown),
+		PageUpDown:   joinKeyLabels("/", viewerKeys.PageUp, viewerKeys.PageDown),
+		HomeEnd:      joinKeyLabels("/", viewerKeys.Home, viewerKeys.End),
+		TabLeftRight: joinKeyLabels("/", browseKeys.TabLeft, browseKeys.TabRight),
+		LeftRight:    joinKeyLabels("/", viewerKeys.Left, viewerKeys.Right),
+		OpenLogs:     keyLabel(browseKeys.OpenLogs),
+		OpenFilter:   keyLabel(browseKeys.OpenFilter),
+		ToggleScope:  keyLabel(browseKeys.ToggleScope),
+		OpenInspect:  keyLabel(browseKeys.OpenInspect),
+		OpenShell:    keyLabel(browseKeys.OpenShell),
+		ToggleWrap:   keyLabel(viewerKeys.ToggleWrap),
+		ToggleFollow: keyLabel(viewerKeys.ToggleFollow),
+		BackClose:    keyLabel(menuKeys.Back),
+	})
 }

--- a/internal/tui/keymap.go
+++ b/internal/tui/keymap.go
@@ -79,6 +79,7 @@ func (m model) selectedContainerListRow() (tables.ContainerListRow, bool) {
 	}
 	return rows[m.browse.ContainerCursor], true
 }
+
 type footerKeyMap struct {
 	bindings []key.Binding
 }

--- a/internal/tui/logs.go
+++ b/internal/tui/logs.go
@@ -13,7 +13,6 @@ const (
 	TailStep    = 200
 )
 
-
 func (m *model) enterLogsMode(container core.ContainerRow) tea.Cmd {
 	m.previousScreen = m.screen
 	m.screen = shared.Logs

--- a/internal/tui/logs.go
+++ b/internal/tui/logs.go
@@ -13,6 +13,7 @@ const (
 	TailStep    = 200
 )
 
+
 func (m *model) enterLogsMode(container core.ContainerRow) tea.Cmd {
 	m.previousScreen = m.screen
 	m.screen = shared.Logs
@@ -34,7 +35,7 @@ func (m *model) enterLogsMode(container core.ContainerRow) tea.Cmd {
 	m.viewer.Filter.Query = ""
 	m.viewer.Filter.Input.SetValue("")
 	m.viewer.ContentType = viewer.ContentTypeLogs
-	m.viewer.ResourceType = viewer.ResourceTypeContainer
+	m.viewer.ResourceType = core.ResourceContainer
 	m.viewer.LoadingMsg = "Loading logs..."
 	m.viewer.EmptyMsg = "No logs found for this container."
 	m.viewer.Breadcrumb = ""

--- a/internal/tui/screens/browse/model.go
+++ b/internal/tui/screens/browse/model.go
@@ -6,10 +6,19 @@ import (
 
 	"easydocker/internal/core"
 	"easydocker/internal/tui/shared"
+	"easydocker/internal/tui/ui/tables"
 	"easydocker/internal/tui/util"
 )
 
 const cursorPageStep = 5
+
+type BrowseData struct {
+	ContainerListRows       []tables.ContainerListRow
+	FilteredImages          []core.ImageRow
+	FilteredNetworks        []core.NetworkRow
+	FilteredVolumes         []core.VolumeRow
+	MetricsLoadingIndicator string
+}
 
 type Model struct {
 	Loading         bool
@@ -27,26 +36,11 @@ type Model struct {
 	Width  int
 	Height int
 
-	DetailProvider                   DetailProvider
-	ListRenderer                     func(width, height int) string
-	ContainerListRows                func() []ContainerListRow
-	FilteredImages                   func() []core.ImageRow
-	FilteredNetworks                 func() []core.NetworkRow
-	FilteredVolumes                  func() []core.VolumeRow
-	ContainerMetricsLoadingIndicator func() string
-}
+	Data BrowseData
 
-type ContainerListRow struct {
-	Kind            int
-	Container       core.ContainerRow
-	ComposeProject  core.ComposeProject
-	ComposeExpanded bool
+	DetailProvider DetailProvider
+	ListRenderer   func(width, height int) string
 }
-
-const (
-	ContainerListRowContainer = iota
-	ContainerListRowComposeProject
-)
 
 func NewModel() Model {
 	return Model{
@@ -87,7 +81,7 @@ func (m Model) View() string {
 		Loading:                 m.Loading,
 		Snapshot:                m.Snapshot,
 		ActiveTab:               m.ActiveTab,
-		MetricsLoadingIndicator: m.containerMetricsLoadingIndicator(),
+		MetricsLoadingIndicator: m.Data.MetricsLoadingIndicator,
 		Width:                   m.Width,
 		Height:                  m.Height,
 		Selections:              m.selections(),
@@ -96,13 +90,6 @@ func (m Model) View() string {
 
 	list := m.ListRenderer(m.Width, ListHeightForContent(m.Height, m.Filter.Active))
 	return RenderContent(vm, list, m.DetailProvider)
-}
-
-func (m Model) containerMetricsLoadingIndicator() string {
-	if m.ContainerMetricsLoadingIndicator != nil {
-		return m.ContainerMetricsLoadingIndicator()
-	}
-	return ""
 }
 
 func (m Model) handleKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
@@ -235,23 +222,23 @@ func (m Model) cursors() shared.Cursors {
 func (m Model) ItemCountForTab(tab shared.Tab) int {
 	switch tab {
 	case shared.TabContainers:
-		if m.ContainerListRows != nil {
-			return len(m.ContainerListRows())
+		if len(m.Data.ContainerListRows) > 0 {
+			return len(m.Data.ContainerListRows)
 		}
 		return len(m.Snapshot.Containers)
 	case shared.TabImages:
-		if m.FilteredImages != nil {
-			return len(m.FilteredImages())
+		if len(m.Data.FilteredImages) > 0 {
+			return len(m.Data.FilteredImages)
 		}
 		return len(m.Snapshot.Images)
 	case shared.TabNetworks:
-		if m.FilteredNetworks != nil {
-			return len(m.FilteredNetworks())
+		if len(m.Data.FilteredNetworks) > 0 {
+			return len(m.Data.FilteredNetworks)
 		}
 		return len(m.Snapshot.Networks)
 	case shared.TabVolumes:
-		if m.FilteredVolumes != nil {
-			return len(m.FilteredVolumes())
+		if len(m.Data.FilteredVolumes) > 0 {
+			return len(m.Data.FilteredVolumes)
 		}
 		return len(m.Snapshot.Volumes)
 	default:
@@ -280,46 +267,44 @@ func (m Model) selections() SelectionSet {
 }
 
 func (m Model) SelectedContainer() (core.ContainerRow, bool) {
-	if m.ContainerListRows == nil {
-		return selectedAt(m.Snapshot.Containers, m.ContainerCursor)
+	if len(m.Data.ContainerListRows) > 0 {
+		row, ok := selectedAt(m.Data.ContainerListRows, m.ContainerCursor)
+		if !ok || row.Kind != tables.ContainerListRowContainer {
+			return core.ContainerRow{}, false
+		}
+		return row.Container, true
 	}
-	rows := m.ContainerListRows()
-	row, ok := selectedAt(rows, m.ContainerCursor)
-	if !ok || row.Kind != ContainerListRowContainer {
-		return core.ContainerRow{}, false
-	}
-	return row.Container, true
+	return selectedAt(m.Snapshot.Containers, m.ContainerCursor)
 }
 
 func (m Model) SelectedComposeProject() (core.ComposeProject, bool) {
-	if m.ContainerListRows == nil {
+	if len(m.Data.ContainerListRows) == 0 {
 		return core.ComposeProject{}, false
 	}
-	rows := m.ContainerListRows()
-	row, ok := selectedAt(rows, m.ContainerCursor)
-	if !ok || row.Kind != ContainerListRowComposeProject {
+	row, ok := selectedAt(m.Data.ContainerListRows, m.ContainerCursor)
+	if !ok || row.Kind != tables.ContainerListRowComposeProject {
 		return core.ComposeProject{}, false
 	}
 	return row.ComposeProject, true
 }
 
 func (m Model) SelectedImage() (core.ImageRow, bool) {
-	if m.FilteredImages != nil {
-		return selectedAt(m.FilteredImages(), m.ImageCursor)
+	if len(m.Data.FilteredImages) > 0 {
+		return selectedAt(m.Data.FilteredImages, m.ImageCursor)
 	}
 	return selectedAt(m.Snapshot.Images, m.ImageCursor)
 }
 
 func (m Model) SelectedNetwork() (core.NetworkRow, bool) {
-	if m.FilteredNetworks != nil {
-		return selectedAt(m.FilteredNetworks(), m.NetworkCursor)
+	if len(m.Data.FilteredNetworks) > 0 {
+		return selectedAt(m.Data.FilteredNetworks, m.NetworkCursor)
 	}
 	return selectedAt(m.Snapshot.Networks, m.NetworkCursor)
 }
 
 func (m Model) SelectedVolume() (core.VolumeRow, bool) {
-	if m.FilteredVolumes != nil {
-		return selectedAt(m.FilteredVolumes(), m.VolumeCursor)
+	if len(m.Data.FilteredVolumes) > 0 {
+		return selectedAt(m.Data.FilteredVolumes, m.VolumeCursor)
 	}
 	return selectedAt(m.Snapshot.Volumes, m.VolumeCursor)
 }
@@ -328,21 +313,19 @@ func (m Model) cursorOnComposeRow() bool {
 	if m.ActiveTab != shared.TabContainers {
 		return false
 	}
-	if m.ContainerListRows == nil {
+	if len(m.Data.ContainerListRows) == 0 {
 		return false
 	}
-	rows := m.ContainerListRows()
-	row, ok := selectedAt(rows, m.ContainerCursor)
-	return ok && row.Kind == ContainerListRowComposeProject
+	row, ok := selectedAt(m.Data.ContainerListRows, m.ContainerCursor)
+	return ok && row.Kind == tables.ContainerListRowComposeProject
 }
 
 func (m Model) toggleCompose() Model {
-	if m.ContainerListRows == nil {
+	if len(m.Data.ContainerListRows) == 0 {
 		return m
 	}
-	rows := m.ContainerListRows()
-	row, ok := selectedAt(rows, m.ContainerCursor)
-	if !ok || row.Kind != ContainerListRowComposeProject {
+	row, ok := selectedAt(m.Data.ContainerListRows, m.ContainerCursor)
+	if !ok || row.Kind != tables.ContainerListRowComposeProject {
 		return m
 	}
 	projectName := row.ComposeProject.Name

--- a/internal/tui/screens/browse/view.go
+++ b/internal/tui/screens/browse/view.go
@@ -172,8 +172,8 @@ func containerDetailLines(container core.ContainerRow, loadingIndicator string, 
 		provider.DetailLine("Image", container.Image, width),
 		provider.DetailLine("State", provider.RenderContainerState(container), width),
 		provider.DetailLine("Status", container.Status, width),
-		provider.DetailLine("CPU", ContainerCPUValue(container, loadingIndicator), width),
-		provider.DetailLine("Memory", ContainerMemoryTableValue(container, loadingIndicator), width),
+		provider.DetailLine("CPU", core.ContainerCPUValue(container, loadingIndicator), width),
+		provider.DetailLine("Memory", core.ContainerMemoryTableValue(container, loadingIndicator), width),
 		provider.DetailLine("Ports", container.Ports, width),
 		provider.DetailLine("Command", container.Command, width),
 		provider.DetailLine("ID", container.ID, width),
@@ -268,49 +268,8 @@ func composeProjectNetworks(networkField string) []string {
 	return networks
 }
 
-func ContainerCPUValue(container core.ContainerRow, loadingIndicator string) string {
-	if container.CPUPercent < 0 {
-		if strings.EqualFold(container.State, "running") {
-			return metricsLoadingValue(loadingIndicator)
-		}
-		return "-"
-	}
-	if container.CPUPercent < 0.05 {
-		if strings.EqualFold(container.State, "running") {
-			return "0.0%"
-		}
-		return "-"
-	}
-	return fmt.Sprintf("%.1f%%", container.CPUPercent)
-}
-
-func ContainerMemoryTableValue(container core.ContainerRow, loadingIndicator string) string {
-	if container.MemoryUsage == "-" || strings.EqualFold(container.MemoryUsage, "loading") {
-		if strings.EqualFold(container.State, "running") {
-			return metricsLoadingValue(loadingIndicator)
-		}
-		return "-"
-	}
-	return fmt.Sprintf("%s", container.MemoryUsage)
-}
-
-func metricsLoadingValue(loadingIndicator string) string {
-	if strings.TrimSpace(loadingIndicator) == "" {
-		return "-"
-	}
-	return loadingIndicator
-}
-
-// RenderFilterHeader renders a plain filter input line followed by a divider.
 func RenderFilterHeader(input string, width int, dividerStyle lipgloss.Style) string {
 	return components.RenderFilterInputOnly(input, width, dividerStyle)
-}
-
-func ContainerStateText(container core.ContainerRow) string {
-	if container.Healthy && container.State == "running" {
-		return "● healthy"
-	}
-	return "● " + container.State
 }
 
 func dynamicInputWidth(prompt string, lineWidth int) int {

--- a/internal/tui/screens/browse/view_test.go
+++ b/internal/tui/screens/browse/view_test.go
@@ -17,7 +17,7 @@ func (fakeProvider) DetailLine(label, value string, width int) string {
 	return util.ConstrainLine(line, width)
 }
 func (fakeProvider) RenderContainerState(container core.ContainerRow) string {
-	return ContainerStateText(container)
+	return core.ContainerStateText(container)
 }
 
 func TestShouldRenderLoading(t *testing.T) {
@@ -220,41 +220,6 @@ func TestRenderDetailClipsLongImageLineAtNarrowWidth(t *testing.T) {
 		if util.DisplayWidth(line) > 40 {
 			t.Fatalf("line exceeds width 40: %q", line)
 		}
-	}
-}
-
-func TestContainerCPUValue_RunningNeverDash(t *testing.T) {
-	loading := ContainerCPUValue(core.ContainerRow{State: "running", CPUPercent: -1}, "⠋")
-	if loading != "⠋" {
-		t.Fatalf("running loading cpu = %q, want spinner icon", loading)
-	}
-
-	idle := ContainerCPUValue(core.ContainerRow{State: "running", CPUPercent: 0}, "⠋")
-	if idle != "0.0%" {
-		t.Fatalf("running zero cpu = %q, want 0.0%%", idle)
-	}
-
-	afterInitial := ContainerCPUValue(core.ContainerRow{State: "running", CPUPercent: -1}, "")
-	if afterInitial != "-" {
-		t.Fatalf("running loading cpu with no indicator = %q, want -", afterInitial)
-	}
-}
-
-func TestContainerMemoryTableValue_OmitsLimit(t *testing.T) {
-	running := core.ContainerRow{State: "running", MemoryUsage: "128 MiB", MemoryLimit: "2 GiB", MemoryPercent: 6.25}
-	got := ContainerMemoryTableValue(running, "⠋")
-	if got != "128 MiB" {
-		t.Fatalf("table memory value = %q, want %q", got, "128 MiB (6.2%)")
-	}
-
-	loading := ContainerMemoryTableValue(core.ContainerRow{State: "running", MemoryUsage: "-"}, "⠋")
-	if loading != "⠋" {
-		t.Fatalf("running placeholder memory value = %q, want spinner icon", loading)
-	}
-
-	afterInitial := ContainerMemoryTableValue(core.ContainerRow{State: "running", MemoryUsage: "-"}, "")
-	if afterInitial != "-" {
-		t.Fatalf("running placeholder memory value with no indicator = %q, want -", afterInitial)
 	}
 }
 

--- a/internal/tui/screens/menu/help_layout.go
+++ b/internal/tui/screens/menu/help_layout.go
@@ -22,10 +22,6 @@ func HelpBodyHeight(containerHeight int, frame lipgloss.Style) int {
 }
 
 func helpBodyLines(commands []HelpCommand, format func(HelpCommand) string) []string {
-	if len(commands) == 0 {
-		commands = buildHelpCommands()
-	}
-
 	lines := make([]string, 0, len(commands))
 	var prevGroup string
 	for _, cmd := range commands {

--- a/internal/tui/screens/menu/types.go
+++ b/internal/tui/screens/menu/types.go
@@ -89,19 +89,19 @@ func NewHelpState(width, height int) HelpState {
 }
 
 type HelpKeyLabels struct {
-	MoveUpDown    string
-	PageUpDown    string
-	HomeEnd       string
-	TabLeftRight  string
-	LeftRight     string
-	OpenLogs      string
-	OpenFilter    string
-	ToggleScope   string
-	OpenInspect   string
-	OpenShell     string
-	ToggleWrap    string
-	ToggleFollow  string
-	BackClose     string
+	MoveUpDown   string
+	PageUpDown   string
+	HomeEnd      string
+	TabLeftRight string
+	LeftRight    string
+	OpenLogs     string
+	OpenFilter   string
+	ToggleScope  string
+	OpenInspect  string
+	OpenShell    string
+	ToggleWrap   string
+	ToggleFollow string
+	BackClose    string
 }
 
 func BuildHelpCommands(labels HelpKeyLabels) []HelpCommand {

--- a/internal/tui/screens/menu/types.go
+++ b/internal/tui/screens/menu/types.go
@@ -1,14 +1,6 @@
 package menu
 
-import (
-	"strings"
-
-	"easydocker/internal/tui/screens/browse"
-	"easydocker/internal/tui/screens/viewer"
-
-	"charm.land/bubbles/v2/key"
-	"charm.land/lipgloss/v2"
-)
+import "charm.land/lipgloss/v2"
 
 type MenuAction int
 
@@ -90,49 +82,45 @@ func NewHelpState(width, height int) HelpState {
 	return HelpState{
 		Active:   false,
 		Cursor:   0,
-		Commands: buildHelpCommands(),
+		Commands: nil,
 		Width:    width,
 		Height:   height,
 	}
 }
 
-func buildHelpCommands() []HelpCommand {
-	browseKeys := browse.NewKeyMap()
-	viewerKeys := viewer.NewKeyMap()
-	menuKeys := NewKeyMap()
+type HelpKeyLabels struct {
+	MoveUpDown    string
+	PageUpDown    string
+	HomeEnd       string
+	TabLeftRight  string
+	LeftRight     string
+	OpenLogs      string
+	OpenFilter    string
+	ToggleScope   string
+	OpenInspect   string
+	OpenShell     string
+	ToggleWrap    string
+	ToggleFollow  string
+	BackClose     string
+}
 
+func BuildHelpCommands(labels HelpKeyLabels) []HelpCommand {
 	return []HelpCommand{
-		navCommand(joinKeyLabels("/", browseKeys.MoveUp, browseKeys.MoveDown), "move up/down", ""),
-		navCommand(joinKeyLabels("/", viewerKeys.PageUp, viewerKeys.PageDown), "page up/down", ""),
-		navCommand(joinKeyLabels("/", viewerKeys.Home, viewerKeys.End), "go to top/bottom", noteModeLogsInspect),
-		navCommand(joinKeyLabels("/", browseKeys.TabLeft, browseKeys.TabRight), "prev/next tab", noteModeBrowse),
-		navCommand(joinKeyLabels("/", viewerKeys.Left, viewerKeys.Right), "scroll left/right", noteModeLogsInspect),
-		enterCommand(keyLabel(browseKeys.OpenLogs), "expand/collapse", noteRowCompose),
-		enterCommand(keyLabel(browseKeys.OpenLogs), "open logs", noteRowContainer),
-		actionCommand(keyLabel(browseKeys.OpenFilter), "filter", ""),
-		actionCommand(keyLabel(browseKeys.ToggleScope), "toggle running/all", noteTabContainers),
-		actionCommand(keyLabel(browseKeys.OpenInspect), "inspect", noteModeBrowse),
-		actionCommand(keyLabel(browseKeys.OpenShell), "interactive shell", noteRowRunningContainer),
-		actionCommand(keyLabel(viewerKeys.ToggleWrap), "toggle wrap", noteModeLogsInspect),
-		actionCommand(keyLabel(viewerKeys.ToggleFollow), "toggle follow", noteModeLogs),
-		actionCommand(keyLabel(menuKeys.Back), "back/close", ""),
+		navCommand(labels.MoveUpDown, "move up/down", ""),
+		navCommand(labels.PageUpDown, "page up/down", ""),
+		navCommand(labels.HomeEnd, "go to top/bottom", noteModeLogsInspect),
+		navCommand(labels.TabLeftRight, "prev/next tab", noteModeBrowse),
+		navCommand(labels.LeftRight, "scroll left/right", noteModeLogsInspect),
+		enterCommand(labels.OpenLogs, "expand/collapse", noteRowCompose),
+		enterCommand(labels.OpenLogs, "open logs", noteRowContainer),
+		actionCommand(labels.OpenFilter, "filter", ""),
+		actionCommand(labels.ToggleScope, "toggle running/all", noteTabContainers),
+		actionCommand(labels.OpenInspect, "inspect", noteModeBrowse),
+		actionCommand(labels.OpenShell, "interactive shell", noteRowRunningContainer),
+		actionCommand(labels.ToggleWrap, "toggle wrap", noteModeLogsInspect),
+		actionCommand(labels.ToggleFollow, "toggle follow", noteModeLogs),
+		actionCommand(labels.BackClose, "back/close", ""),
 	}
-}
-
-func keyLabel(binding key.Binding) string {
-	return strings.TrimSpace(binding.Help().Key)
-}
-
-func joinKeyLabels(sep string, bindings ...key.Binding) string {
-	labels := make([]string, 0, len(bindings))
-	for _, binding := range bindings {
-		label := keyLabel(binding)
-		if label == "" {
-			continue
-		}
-		labels = append(labels, label)
-	}
-	return strings.Join(labels, sep)
 }
 
 func navCommand(keyLabel, description, note string) HelpCommand {

--- a/internal/tui/screens/viewer/keymap.go
+++ b/internal/tui/screens/viewer/keymap.go
@@ -1,6 +1,7 @@
 package viewer
 
 import (
+	"easydocker/internal/core"
 	"easydocker/internal/tui/shared"
 
 	"charm.land/bubbles/v2/key"
@@ -40,7 +41,7 @@ func NewKeyMap() KeyMap {
 	}
 }
 
-func (k KeyMap) ShortHelp(resourceType ResourceType, contentType ContentType, containerState string) []key.Binding {
+func (k KeyMap) ShortHelp(resourceType core.ResourceType, contentType ContentType, containerState string) []key.Binding {
 	bindings := []key.Binding{
 		k.ToggleWrap, k.Back,
 	}
@@ -51,7 +52,7 @@ func (k KeyMap) ShortHelp(resourceType ResourceType, contentType ContentType, co
 		bindings = append(bindings, k.ToggleFollow)
 	}
 
-	if resourceType == ResourceTypeContainer && shared.CanOpenShell(containerState) {
+	if resourceType == core.ResourceContainer && shared.CanOpenShell(containerState) {
 		bindings = append(bindings, k.OpenShell)
 	}
 

--- a/internal/tui/screens/viewer/model.go
+++ b/internal/tui/screens/viewer/model.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"time"
 
+	"easydocker/internal/core"
 	"easydocker/internal/tui/shared"
 
 	"charm.land/bubbles/v2/key"
@@ -20,7 +21,7 @@ type Model struct {
 	EmptyMsg      string
 	Breadcrumb    string
 	ContainerName string
-	ResourceType  ResourceType
+	ResourceType  core.ResourceType
 	Width         int
 	Height        int
 	Styles        ViewStyles

--- a/internal/tui/screens/viewer/types.go
+++ b/internal/tui/screens/viewer/types.go
@@ -61,15 +61,6 @@ const (
 	ContentTypeInspect
 )
 
-type ResourceType int
-
-const (
-	ResourceTypeContainer ResourceType = iota
-	ResourceTypeVolume
-	ResourceTypeNetwork
-	ResourceTypeImage
-)
-
 type State struct {
 	ContainerID  string
 	Data         []string

--- a/internal/tui/screens/viewer/view.go
+++ b/internal/tui/screens/viewer/view.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"easydocker/internal/core"
 	"easydocker/internal/tui/ui/components"
 	"easydocker/internal/tui/util"
 
@@ -31,7 +32,7 @@ type ViewModel struct {
 	Height           int
 	Styles           ViewStyles
 	ContentType      ContentType
-	ResourceType     ResourceType
+	ResourceType     core.ResourceType
 	HistoryLoad      bool
 }
 
@@ -46,7 +47,7 @@ func RenderContent(vm ViewModel) string {
 	headerVM.Width = layout.ContentWidth
 	breadcrumb := vm.Breadcrumb
 	if breadcrumb == "" {
-		resourceLabel := getResourceLabel(vm.ResourceType)
+		resourceLabel := core.ResourceLabel(vm.ResourceType)
 		contentLabel := getContentLabel(vm.ContentType)
 		breadcrumb = util.ClampSingleLine(
 			fmt.Sprintf("%s / %s / %s", resourceLabel, vm.ContainerName, contentLabel),
@@ -225,25 +226,6 @@ func renderRightPriorityLine(left, right string, width int) string {
 	leftRenderedWidth := util.DisplayWidth(left)
 	spacing := max(0, width-leftRenderedWidth-rightWidth)
 	return left + strings.Repeat(" ", spacing) + right
-}
-
-func getResourceLabel(rt ResourceType) string {
-	switch rt {
-	case ResourceTypeContainer:
-		return "Containers"
-	case ResourceTypeVolume:
-		return "Volumes"
-	case ResourceTypeNetwork:
-		return "Networks"
-	case ResourceTypeImage:
-		return "Images"
-	default:
-		return "Containers"
-	}
-}
-
-func GetResourceLabel(rt ResourceType) string {
-	return getResourceLabel(rt)
 }
 
 func getContentLabel(ct ContentType) string {

--- a/internal/tui/selection.go
+++ b/internal/tui/selection.go
@@ -80,12 +80,8 @@ func (m model) filteredVolumes() []core.VolumeRow {
 	return core.FilterVolumesByQuery(m.browse.Snapshot.Volumes, m.browse.Filter.Query)
 }
 
-func (m model) containerListRows() []tables.ContainerListRow {
-	return tables.BuildContainerListRows(m.filteredContainers(), m.browse.ComposeExpanded)
-}
-
 func (m model) findContainerIndexByID(id string) (int, bool) {
-	for index, row := range m.containerListRows() {
+	for index, row := range m.browse.Data.ContainerListRows {
 		if row.Kind != tables.ContainerListRowContainer {
 			continue
 		}

--- a/internal/tui/shared/keymap.go
+++ b/internal/tui/shared/keymap.go
@@ -1,10 +1,12 @@
 package shared
 
 import (
-	"easydocker/internal/tui/util"
-
 	"charm.land/bubbles/v2/key"
 )
+
+func helpKeyLabel(label string) string {
+	return " " + label + " "
+}
 
 func UpBinding(help string) key.Binding {
 	return key.NewBinding(
@@ -65,7 +67,7 @@ func EndBinding(help string) key.Binding {
 func ActionBinding(keyName, help string) key.Binding {
 	return key.NewBinding(
 		key.WithKeys(keyName),
-		key.WithHelp(util.HelpKeyLabel(keyName), help),
+		key.WithHelp(helpKeyLabel(keyName), help),
 	)
 }
 

--- a/internal/tui/shared/tabs.go
+++ b/internal/tui/shared/tabs.go
@@ -1,5 +1,7 @@
 package shared
 
+import "easydocker/internal/core"
+
 // Tab identifies a resource tab in the browse screen.
 type Tab int
 
@@ -23,5 +25,20 @@ func (t Tab) String() string {
 		return "Volumes"
 	default:
 		return "Unknown"
+	}
+}
+
+func TabToResourceType(tab Tab) core.ResourceType {
+	switch tab {
+	case TabContainers:
+		return core.ResourceContainer
+	case TabImages:
+		return core.ResourceImage
+	case TabNetworks:
+		return core.ResourceNetwork
+	case TabVolumes:
+		return core.ResourceVolume
+	default:
+		return core.ResourceContainer
 	}
 }

--- a/internal/tui/sync.go
+++ b/internal/tui/sync.go
@@ -1,0 +1,21 @@
+package tui
+
+import (
+	"easydocker/internal/tui/screens/browse"
+	"easydocker/internal/tui/ui/tables"
+)
+
+func (m model) syncBrowseData() model {
+	m.browse.Data = browse.BrowseData{
+		ContainerListRows:       tables.BuildContainerListRows(m.filteredContainers(), m.browse.ComposeExpanded),
+		FilteredImages:          m.filteredImages(),
+		FilteredNetworks:        m.filteredNetworks(),
+		FilteredVolumes:         m.filteredVolumes(),
+		MetricsLoadingIndicator: m.containerMetricsLoadingIndicator(),
+	}
+	m.browse.DetailProvider = m.browseDetailRenderer()
+	m.browse.ListRenderer = func(width, h int) string {
+		return m.renderResourceList(width, h)
+	}
+	return m
+}

--- a/internal/tui/ui/chrome/view.go
+++ b/internal/tui/ui/chrome/view.go
@@ -2,6 +2,7 @@ package chrome
 
 import (
 	"fmt"
+	"math"
 	"strings"
 
 	"easydocker/internal/core"
@@ -10,6 +11,23 @@ import (
 	"charm.land/bubbles/v2/help"
 	"charm.land/lipgloss/v2"
 )
+
+func formatMemoryUsage(usage string, percent float64, limit string) string {
+	if usage == "-" {
+		return "-"
+	}
+	if limit != "" && limit != "-" {
+		return fmt.Sprintf("%s / %s (%s)", usage, limit, renderPercent(percent))
+	}
+	return fmt.Sprintf("%s (%s)", usage, renderPercent(percent))
+}
+
+func renderPercent(value float64) string {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return "-"
+	}
+	return fmt.Sprintf("%.1f%%", value)
+}
 
 type TabSpec struct {
 	Tab   int
@@ -143,9 +161,9 @@ func RenderTotalsLabel(snapshot core.Snapshot, loadingStage, loadStageIdle, load
 	}
 	mem := core.HumanBytes(int64(snapshot.TotalMem))
 	if snapshot.TotalLimit > 0 {
-		return fmt.Sprintf("CPU %s  MEM %s", util.RenderPercent(snapshot.TotalCPU), util.FormatMemoryUsage(mem, (float64(snapshot.TotalMem)/float64(snapshot.TotalLimit))*100, core.HumanBytes(int64(snapshot.TotalLimit))))
+		return fmt.Sprintf("CPU %s  MEM %s", renderPercent(snapshot.TotalCPU), formatMemoryUsage(mem, (float64(snapshot.TotalMem)/float64(snapshot.TotalLimit))*100, core.HumanBytes(int64(snapshot.TotalLimit))))
 	}
-	return fmt.Sprintf("CPU %s  MEM %s", util.RenderPercent(snapshot.TotalCPU), mem)
+	return fmt.Sprintf("CPU %s  MEM %s", renderPercent(snapshot.TotalCPU), mem)
 }
 
 func RenderLoadingStageLabel(loadingStage, loadStageContainers, loadStageResources, loadStageMetrics int, metricsLoaded bool) string {

--- a/internal/tui/ui/tables/basic_rows.go
+++ b/internal/tui/ui/tables/basic_rows.go
@@ -1,0 +1,96 @@
+package tables
+
+import (
+	"fmt"
+	"strings"
+
+	"easydocker/internal/core"
+	"easydocker/internal/tui/util"
+)
+
+// ImageColumns resolves image columns for a given table width.
+func ImageColumns(tableWidth int) []ColumnDef {
+	return ResolveColumns(tableWidth, ImageSchema)
+}
+
+// NetworkColumns resolves network columns for a given table width.
+func NetworkColumns(tableWidth int) []ColumnDef {
+	return ResolveColumns(tableWidth, NetworkSchema)
+}
+
+// VolumeColumns resolves volume columns for a given table width.
+func VolumeColumns(tableWidth int) []ColumnDef {
+	return ResolveColumns(tableWidth, VolumeSchema)
+}
+
+// BuildImageSpec builds a complete images table spec.
+func BuildImageSpec(width, cursor int, items []core.ImageRow) Spec[core.ImageRow] {
+	return SimpleSpec(width, "No images found.", cursor, items, ImageColumns, ImageTableRow)
+}
+
+// BuildNetworkSpec builds a complete networks table spec.
+func BuildNetworkSpec(width, cursor int, items []core.NetworkRow) Spec[core.NetworkRow] {
+	return SimpleSpec(width, "No networks found.", cursor, items, NetworkColumns, NetworkTableRow)
+}
+
+// BuildVolumeSpec builds a complete volumes table spec.
+func BuildVolumeSpec(width, cursor int, items []core.VolumeRow) Spec[core.VolumeRow] {
+	return SimpleSpec(width, "No volumes found.", cursor, items, VolumeColumns, VolumeTableRow)
+}
+
+// ImageTableRow builds a single row for the images table.
+func ImageTableRow(image core.ImageRow) []string {
+	repository, tags := splitImageTags(image.Tags)
+	return []string{repository, tags, image.Size, image.Created, image.ID}
+}
+
+func splitImageTags(formattedTags string) (string, string) {
+	if formattedTags == "" {
+		return "-", "-"
+	}
+
+	repositories := make([]string, 0, 4)
+	tags := make([]string, 0, 4)
+	for _, reference := range strings.Split(formattedTags, ", ") {
+		repository, tag := splitImageTagReference(reference)
+		repositories = append(repositories, repository)
+		tags = append(tags, tag)
+	}
+
+	return strings.Join(repositories, ", "), strings.Join(tags, ", ")
+}
+
+func splitImageTagReference(reference string) (string, string) {
+	if reference == "<none>:<none>" {
+		return "<none>", "<none>"
+	}
+
+	lastColon := strings.LastIndex(reference, ":")
+	if lastColon <= 0 || lastColon == len(reference)-1 {
+		return reference, "-"
+	}
+
+	return reference[:lastColon], reference[lastColon+1:]
+}
+
+// NetworkTableRow builds a single row for the networks table.
+func NetworkTableRow(network core.NetworkRow) []string {
+	return []string{
+		network.Name,
+		network.Driver,
+		network.Scope,
+		fmt.Sprintf("%d", network.Endpoints),
+		fmt.Sprintf("internal:%s attach:%s", network.Internal, network.Attachable),
+	}
+}
+
+// VolumeTableRow builds a single row for the volumes table.
+func VolumeTableRow(volume core.VolumeRow) []string {
+	return []string{
+		volume.Name,
+		volume.Driver,
+		volume.Scope,
+		volume.Size,
+		util.RefCountText(volume.RefCount),
+	}
+}

--- a/internal/tui/ui/tables/container_rows.go
+++ b/internal/tui/ui/tables/container_rows.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"easydocker/internal/core"
-	"easydocker/internal/tui/screens/browse"
 	"easydocker/internal/tui/util"
 )
 
@@ -27,21 +26,6 @@ type ContainerListRow struct {
 // ContainerColumns resolves container columns for a given table width.
 func ContainerColumns(tableWidth int) []ColumnDef {
 	return ResolveColumns(tableWidth, ContainerSchema)
-}
-
-// ImageColumns resolves image columns for a given table width.
-func ImageColumns(tableWidth int) []ColumnDef {
-	return ResolveColumns(tableWidth, ImageSchema)
-}
-
-// NetworkColumns resolves network columns for a given table width.
-func NetworkColumns(tableWidth int) []ColumnDef {
-	return ResolveColumns(tableWidth, NetworkSchema)
-}
-
-// VolumeColumns resolves volume columns for a given table width.
-func VolumeColumns(tableWidth int) []ColumnDef {
-	return ResolveColumns(tableWidth, VolumeSchema)
 }
 
 // BuildContainerListRows creates a flat row model that includes compose project rows.
@@ -143,31 +127,16 @@ func BuildContainerSpec(width, cursor int, items []ContainerListRow, includeScop
 	}
 }
 
-// BuildImageSpec builds a complete images table spec.
-func BuildImageSpec(width, cursor int, items []core.ImageRow) Spec[core.ImageRow] {
-	return SimpleSpec(width, "No images found.", cursor, items, ImageColumns, ImageTableRow)
-}
-
-// BuildNetworkSpec builds a complete networks table spec.
-func BuildNetworkSpec(width, cursor int, items []core.NetworkRow) Spec[core.NetworkRow] {
-	return SimpleSpec(width, "No networks found.", cursor, items, NetworkColumns, NetworkTableRow)
-}
-
-// BuildVolumeSpec builds a complete volumes table spec.
-func BuildVolumeSpec(width, cursor int, items []core.VolumeRow) Spec[core.VolumeRow] {
-	return SimpleSpec(width, "No volumes found.", cursor, items, VolumeColumns, VolumeTableRow)
-}
-
 // ContainerTableRow builds a single row for the containers table.
 func ContainerTableRow(container core.ContainerRow, stateWidth int, loadingIndicator, treePrefix string) []string {
-	state := browse.ContainerStateText(container)
+	state := core.ContainerStateText(container)
 	if stateWidth > 0 && util.StripANSI(util.TruncateWithEllipsis(state, stateWidth)) == "…" {
 		state = "●"
 	}
 	state = colorStateLabel(state, container.State)
 	name := container.Name
-	cpu := browse.ContainerCPUValue(container, loadingIndicator)
-	mem := browse.ContainerMemoryTableValue(container, loadingIndicator)
+	cpu := core.ContainerCPUValue(container, loadingIndicator)
+	mem := core.ContainerMemoryTableValue(container, loadingIndicator)
 	if treePrefix != "" {
 		name = treePrefix + name
 		cpu = childMetricGuidePrefix(treePrefix) + cpu
@@ -225,77 +194,19 @@ func ansiBold(value string) string {
 	return "\x1b[1m" + value + "\x1b[22m"
 }
 
-// ImageTableRow builds a single row for the images table.
-func ImageTableRow(image core.ImageRow) []string {
-	repository, tags := splitImageTags(image.Tags)
-	return []string{repository, tags, image.Size, image.Created, image.ID}
-}
-
-func splitImageTags(formattedTags string) (string, string) {
-	if formattedTags == "" {
-		return "-", "-"
-	}
-
-	repositories := make([]string, 0, 4)
-	tags := make([]string, 0, 4)
-	for _, reference := range strings.Split(formattedTags, ", ") {
-		repository, tag := splitImageTagReference(reference)
-		repositories = append(repositories, repository)
-		tags = append(tags, tag)
-	}
-
-	return strings.Join(repositories, ", "), strings.Join(tags, ", ")
-}
-
-func splitImageTagReference(reference string) (string, string) {
-	if reference == "<none>:<none>" {
-		return "<none>", "<none>"
-	}
-
-	lastColon := strings.LastIndex(reference, ":")
-	if lastColon <= 0 || lastColon == len(reference)-1 {
-		return reference, "-"
-	}
-
-	return reference[:lastColon], reference[lastColon+1:]
-}
-
-// NetworkTableRow builds a single row for the networks table.
-func NetworkTableRow(network core.NetworkRow) []string {
-	return []string{
-		network.Name,
-		network.Driver,
-		network.Scope,
-		fmt.Sprintf("%d", network.Endpoints),
-		fmt.Sprintf("internal:%s attach:%s", network.Internal, network.Attachable),
-	}
-}
-
-// VolumeTableRow builds a single row for the volumes table.
-func VolumeTableRow(volume core.VolumeRow) []string {
-	return []string{
-		volume.Name,
-		volume.Driver,
-		volume.Scope,
-		volume.Size,
-		util.RefCountText(volume.RefCount),
-	}
-}
-
 func colorStateLabel(label, state string) string {
-	code := "37"
+	var code string
 	switch strings.ToLower(state) {
 	case "running":
-		code = "32"
+		code = "42"
 	case "paused", "restarting", "created":
-		code = "33"
+		code = "214"
 	case "exited", "stopped":
-		code = "31"
+		code = "203"
 	case "dead":
-		code = "91"
+		code = "199"
 	default:
-		code = "36"
+		code = "110"
 	}
-	// Reset only the foreground so selected-row background remains intact.
-	return "\x1b[" + code + "m" + label + "\x1b[39m"
+	return "\x1b[38;5;" + code + "m" + label + "\x1b[39m"
 }

--- a/internal/tui/ui/tables/render.go
+++ b/internal/tui/ui/tables/render.go
@@ -1,13 +1,59 @@
 package tables
 
 import (
-	"easydocker/internal/tui/ui/tables/btable"
 	"easydocker/internal/tui/util"
 
 	"charm.land/lipgloss/v2"
 )
 
 type Row []string
+
+// allocateColumns distributes total width across desired column widths.
+func allocateColumns(total int, desired []int) []int {
+	if len(desired) == 0 {
+		return []int{}
+	}
+	if total <= 0 {
+		out := make([]int, len(desired))
+		for i := range out {
+			out[i] = 1
+		}
+		return out
+	}
+
+	out := make([]int, len(desired))
+	sum := 0
+	for i, width := range desired {
+		if width < 1 {
+			width = 1
+		}
+		out[i] = width
+		sum += width
+	}
+	if sum == total {
+		return out
+	}
+	if sum < total {
+		out[len(out)-1] += total - sum
+		return out
+	}
+
+	over := sum - total
+	for over > 0 {
+		changed := false
+		for i := range out {
+			if out[i] > 1 && over > 0 {
+				out[i]--
+				over--
+				changed = true
+			}
+		}
+		if !changed {
+			break
+		}
+	}
+	return out
+}
 
 type Styles struct {
 	Header   lipgloss.Style
@@ -34,7 +80,7 @@ func ResolveColumns(tableWidth int, defs []ColumnDef) []ColumnDef {
 		desired = append(desired, width)
 	}
 
-	widths := util.AllocateColumns(max(1, tableWidth-((len(defs)-1)*2)), desired)
+	widths := allocateColumns(max(1, tableWidth-((len(defs)-1)*2)), desired)
 	resolved := make([]ColumnDef, 0, len(defs))
 	for index, def := range defs {
 		def.MinWidth = widths[index]
@@ -63,34 +109,34 @@ func RenderOrEmpty(width, height int, emptyMessage string, columns []ColumnDef, 
 	if len(rows) == 0 {
 		return util.ConstrainLine(emptyMessage, width)
 	}
-	return RenderBubblesTable(styles, width, height, columns, rows, cursor)
+	return renderTable(styles, width, height, columns, rows, cursor)
 }
 
-// RenderBubblesTable creates a rendered btable.Table with styled rows and cursor.
-func RenderBubblesTable(styles Styles, width, height int, defs []ColumnDef, rows []Row, cursor int) string {
-	cols := make([]btable.Column, 0, len(defs))
+// renderTable creates a rendered table with styled rows and cursor.
+func renderTable(styles Styles, width, height int, defs []ColumnDef, rows []Row, cursor int) string {
+	cols := make([]tableColumn, 0, len(defs))
 	for _, def := range defs {
-		cols = append(cols, btable.Column{Title: def.Header, Width: def.MinWidth})
+		cols = append(cols, tableColumn{Title: def.Header, Width: def.MinWidth})
 	}
-	privateRows := make([]btable.Row, 0, len(rows))
+	privateRows := make([]tableRow, 0, len(rows))
 	for _, row := range rows {
-		privateRows = append(privateRows, btable.Row(row))
+		privateRows = append(privateRows, tableRow(row))
 	}
-	privateStyles := btable.Styles{
+	privateStyles := tableStyles{
 		Header:   styles.Header,
 		Cell:     styles.Cell,
 		Selected: styles.Selected,
 	}
 
-	t := btable.New(
-		btable.WithColumns(cols),
-		btable.WithRows(privateRows),
-		btable.WithStyles(privateStyles),
-		btable.WithWidth(max(1, width)),
-		btable.WithHeight(max(2, height)),
+	t := newTable(
+		withColumns(cols),
+		withRows(privateRows),
+		withStyles(privateStyles),
+		withWidth(max(1, width)),
+		withHeight(max(2, height)),
 	)
 	if len(rows) > 0 {
-		t.SetCursor(util.Clamp(cursor, 0, len(rows)-1))
+		t.setCursor(util.Clamp(cursor, 0, len(rows)-1))
 	}
-	return t.View()
+	return t.view()
 }

--- a/internal/tui/ui/tables/table.go
+++ b/internal/tui/ui/tables/table.go
@@ -1,4 +1,4 @@
-package btable
+package tables
 
 import (
 	"strings"
@@ -9,41 +9,41 @@ import (
 	"charm.land/lipgloss/v2"
 )
 
-type Row []string
+type tableRow []string
 
-type Column struct {
+type tableColumn struct {
 	Title string
 	Width int
 }
 
-type Styles struct {
+type tableStyles struct {
 	Header   lipgloss.Style
 	Cell     lipgloss.Style
 	Selected lipgloss.Style
 }
 
-func DefaultStyles() Styles {
-	return Styles{
+func defaultTableStyles() tableStyles {
+	return tableStyles{
 		Header:   lipgloss.NewStyle().Bold(true),
 		Cell:     lipgloss.NewStyle(),
 		Selected: lipgloss.NewStyle().Bold(true),
 	}
 }
 
-type Model struct {
-	cols   []Column
-	rows   []Row
+type tableModel struct {
+	cols   []tableColumn
+	rows   []tableRow
 	cursor int
-	styles Styles
+	styles tableStyles
 
 	viewport viewport.Model
 }
 
-type Option func(*Model)
+type tableOption func(*tableModel)
 
-func New(opts ...Option) Model {
-	m := Model{
-		styles:   DefaultStyles(),
+func newTable(opts ...tableOption) tableModel {
+	m := tableModel{
+		styles:   defaultTableStyles(),
 		viewport: viewport.New(viewport.WithWidth(0), viewport.WithHeight(20)),
 	}
 	for _, opt := range opts {
@@ -53,38 +53,38 @@ func New(opts ...Option) Model {
 	return m
 }
 
-func WithColumns(cols []Column) Option {
-	return func(m *Model) {
+func withColumns(cols []tableColumn) tableOption {
+	return func(m *tableModel) {
 		m.cols = cols
 	}
 }
 
-func WithRows(rows []Row) Option {
-	return func(m *Model) {
+func withRows(rows []tableRow) tableOption {
+	return func(m *tableModel) {
 		m.rows = rows
 	}
 }
 
-func WithHeight(h int) Option {
-	return func(m *Model) {
+func withHeight(h int) tableOption {
+	return func(m *tableModel) {
 		headerHeight := lipgloss.Height(m.headersView())
 		m.viewport.SetHeight(max(1, h-headerHeight))
 	}
 }
 
-func WithWidth(w int) Option {
-	return func(m *Model) {
+func withWidth(w int) tableOption {
+	return func(m *tableModel) {
 		m.viewport.SetWidth(max(1, w))
 	}
 }
 
-func WithStyles(s Styles) Option {
-	return func(m *Model) {
+func withStyles(s tableStyles) tableOption {
+	return func(m *tableModel) {
 		m.styles = s
 	}
 }
 
-func (m *Model) SetCursor(n int) {
+func (m *tableModel) setCursor(n int) {
 	if len(m.rows) == 0 {
 		m.cursor = 0
 		m.updateViewport()
@@ -94,7 +94,7 @@ func (m *Model) SetCursor(n int) {
 	m.updateViewport()
 }
 
-func (m Model) View() string {
+func (m tableModel) view() string {
 	header := m.styles.Header.Render(m.headersView())
 	body := m.viewport.View()
 	if body == "" {
@@ -103,7 +103,7 @@ func (m Model) View() string {
 	return header + "\n" + body
 }
 
-func (m *Model) updateViewport() {
+func (m *tableModel) updateViewport() {
 	if m.viewport.Width() <= 0 {
 		m.viewport.SetWidth(1)
 	}
@@ -127,7 +127,7 @@ func (m *Model) updateViewport() {
 	m.viewport.SetYOffset(0)
 }
 
-func (m Model) headersView() string {
+func (m tableModel) headersView() string {
 	parts := make([]string, 0, len(m.cols))
 	for _, col := range m.cols {
 		if col.Width <= 0 {
@@ -138,7 +138,7 @@ func (m Model) headersView() string {
 	return joinWithGap(parts, "  ")
 }
 
-func (m Model) renderRow(rowIndex int) string {
+func (m tableModel) renderRow(rowIndex int) string {
 	parts := make([]string, 0, len(m.cols))
 	for colIndex, col := range m.cols {
 		if col.Width <= 0 {

--- a/internal/tui/ui/tables/table_test.go
+++ b/internal/tui/ui/tables/table_test.go
@@ -1,4 +1,4 @@
-package btable
+package tables
 
 import (
 	"strings"
@@ -6,11 +6,11 @@ import (
 )
 
 func TestRenderRow_ColoredCellDoesNotSpillIntoNextColumn(t *testing.T) {
-	m := New(
-		WithColumns([]Column{{Title: "STATE", Width: 4}, {Title: "STATUS", Width: 6}}),
-		WithRows([]Row{{"\x1b[32mrunning\x1b[39m", "ok"}}),
-		WithWidth(20),
-		WithHeight(2),
+	m := newTable(
+		withColumns([]tableColumn{{Title: "STATE", Width: 4}, {Title: "STATUS", Width: 6}}),
+		withRows([]tableRow{{"\x1b[32mrunning\x1b[39m", "ok"}}),
+		withWidth(20),
+		withHeight(2),
 	)
 
 	row := m.renderRow(0)

--- a/internal/tui/ui/theme/browse.go
+++ b/internal/tui/ui/theme/browse.go
@@ -3,15 +3,15 @@ package theme
 import "charm.land/lipgloss/v2"
 
 func applyBrowseStyles(s *Set) {
-	s.Section = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("186"))
-	s.Label = lipgloss.NewStyle().Foreground(lipgloss.Color("109"))
-	s.Value = lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
-	s.Muted = lipgloss.NewStyle().Foreground(lipgloss.Color("244"))
-	s.Divider = lipgloss.NewStyle().Foreground(lipgloss.Color("60"))
+	s.Section = lipgloss.NewStyle().Bold(true).Foreground(Gold)
+	s.Label = lipgloss.NewStyle().Foreground(Teal)
+	s.Value = lipgloss.NewStyle().Foreground(TextSecondary)
+	s.Muted = lipgloss.NewStyle().Foreground(TextMuted)
+	s.Divider = lipgloss.NewStyle().Foreground(MutedPurple)
 
-	s.StateRun = lipgloss.NewStyle().Foreground(lipgloss.Color("42"))
-	s.StateWarn = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
-	s.StateStop = lipgloss.NewStyle().Foreground(lipgloss.Color("203"))
-	s.StateDead = lipgloss.NewStyle().Foreground(lipgloss.Color("199"))
-	s.StateOther = lipgloss.NewStyle().Foreground(lipgloss.Color("110"))
+	s.StateRun = lipgloss.NewStyle().Foreground(Green)
+	s.StateWarn = lipgloss.NewStyle().Foreground(Orange)
+	s.StateStop = lipgloss.NewStyle().Foreground(Red)
+	s.StateDead = lipgloss.NewStyle().Foreground(Pink)
+	s.StateOther = lipgloss.NewStyle().Foreground(BlueGray)
 }

--- a/internal/tui/ui/theme/chrome.go
+++ b/internal/tui/ui/theme/chrome.go
@@ -4,13 +4,13 @@ import "charm.land/lipgloss/v2"
 
 func applyChromeStyles(s *Set) {
 	s.Header = lipgloss.NewStyle().Padding(0, 1, 0, 1)
-	s.Title = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("230")).Background(lipgloss.Color("24")).Padding(0, 1)
-	s.TitleMeta = lipgloss.NewStyle().Foreground(lipgloss.Color("252")).Background(lipgloss.Color("24")).Padding(0, 1)
-	s.Tab = lipgloss.NewStyle().Foreground(lipgloss.Color("252")).Padding(0, 1)
-	s.ActiveTab = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("86")).Underline(true).Padding(0, 1)
-	s.Badge = lipgloss.NewStyle().Foreground(lipgloss.Color("229")).Background(lipgloss.Color("60")).Padding(0, 1)
-	s.Footer = lipgloss.NewStyle().Padding(0, 0, 0, 0).Foreground(lipgloss.Color("248"))
-	s.Key = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("230")).Background(lipgloss.Color("31")).Padding(0, 1)
-	s.KeyText = lipgloss.NewStyle().Foreground(lipgloss.Color("248"))
-	s.ErrorText = lipgloss.NewStyle().Foreground(lipgloss.Color("203"))
+	s.Title = lipgloss.NewStyle().Bold(true).Foreground(TextPrimary).Background(SurfaceBG).Padding(0, 1)
+	s.TitleMeta = lipgloss.NewStyle().Foreground(TextSecondary).Background(SurfaceBG).Padding(0, 1)
+	s.Tab = lipgloss.NewStyle().Foreground(TextSecondary).Padding(0, 1)
+	s.ActiveTab = lipgloss.NewStyle().Bold(true).Foreground(Cyan).Underline(true).Padding(0, 1)
+	s.Badge = lipgloss.NewStyle().Foreground(LightYellow).Background(MutedPurple).Padding(0, 1)
+	s.Footer = lipgloss.NewStyle().Padding(0, 0, 0, 0).Foreground(TextDim)
+	s.Key = lipgloss.NewStyle().Bold(true).Foreground(TextPrimary).Background(SteelBlue).Padding(0, 1)
+	s.KeyText = lipgloss.NewStyle().Foreground(TextDim)
+	s.ErrorText = lipgloss.NewStyle().Foreground(Red)
 }

--- a/internal/tui/ui/theme/default.go
+++ b/internal/tui/ui/theme/default.go
@@ -3,8 +3,7 @@ package theme
 import "charm.land/lipgloss/v2"
 
 func Default() Set {
-	activeBG := lipgloss.Color("236")
-	s := Set{Page: lipgloss.NewStyle(), ActiveBG: activeBG}
+	s := Set{Page: lipgloss.NewStyle(), ActiveBG: Surface}
 	applyChromeStyles(&s)
 	applyBrowseStyles(&s)
 	applyLogsStyles(&s)

--- a/internal/tui/ui/theme/layout.go
+++ b/internal/tui/ui/theme/layout.go
@@ -3,6 +3,6 @@ package theme
 import "charm.land/lipgloss/v2"
 
 func applyFrameStyles(s *Set) {
-	s.MainFrame = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("67")).Padding(0, 1)
-	s.SubpageFrame = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("110")).Padding(0, 1)
+	s.MainFrame = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(Periwinkle).Padding(0, 1)
+	s.SubpageFrame = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(BlueGray).Padding(0, 1)
 }

--- a/internal/tui/ui/theme/logs.go
+++ b/internal/tui/ui/theme/logs.go
@@ -3,8 +3,7 @@ package theme
 import "charm.land/lipgloss/v2"
 
 func applyLogsStyles(s *Set) {
-	s.Breadcrumb = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("247"))
-	s.FollowOn = lipgloss.NewStyle().Foreground(lipgloss.Color("252")).Bold(true)
-	s.FollowOff = lipgloss.NewStyle().Foreground(lipgloss.Color("244"))
-	s.MonitorBox = lipgloss.NewStyle().Border(lipgloss.NormalBorder()).BorderForeground(lipgloss.Color("60")).Padding(0, 1)
+	s.Breadcrumb = lipgloss.NewStyle().Bold(true).Foreground(TextBreadcrumb)
+	s.FollowOn = lipgloss.NewStyle().Foreground(TextSecondary).Bold(true)
+	s.FollowOff = lipgloss.NewStyle().Foreground(TextMuted)
 }

--- a/internal/tui/ui/theme/menu.go
+++ b/internal/tui/ui/theme/menu.go
@@ -3,16 +3,16 @@ package theme
 import "charm.land/lipgloss/v2"
 
 func applyMenuStyles(s *Set) {
-	s.MenuFrame = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("67")).Background(lipgloss.Color("234")).Padding(1, 2)
-	s.MenuSelector = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("230"))
-	s.MenuItem = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("244"))
-	s.MenuDesc = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("250"))
-	s.HelpFrame = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("110")).Background(lipgloss.Color("234")).Padding(1, 2)
-	s.HelpTitle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("186"))
-	s.HelpSection = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("109"))
-	s.HelpCommand = lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
-	s.HelpKey = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("230"))
-	s.HelpFooter = lipgloss.NewStyle().Foreground(lipgloss.Color("244"))
-	s.Scrollbar = lipgloss.NewStyle().Foreground(lipgloss.Color("110"))
-	s.HelpContext = lipgloss.NewStyle().Foreground(lipgloss.Color("110"))
+	s.MenuFrame = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(Periwinkle).Background(SurfaceDeep).Padding(1, 2)
+	s.MenuSelector = lipgloss.NewStyle().Bold(true).Foreground(TextPrimary)
+	s.MenuItem = lipgloss.NewStyle().Bold(true).Foreground(TextMuted)
+	s.MenuDesc = lipgloss.NewStyle().Bold(true).Foreground(TextSilver)
+	s.HelpFrame = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(BlueGray).Background(SurfaceDeep).Padding(1, 2)
+	s.HelpTitle = lipgloss.NewStyle().Bold(true).Foreground(Gold)
+	s.HelpSection = lipgloss.NewStyle().Bold(true).Foreground(Teal)
+	s.HelpCommand = lipgloss.NewStyle().Foreground(TextSecondary)
+	s.HelpKey = lipgloss.NewStyle().Bold(true).Foreground(TextPrimary)
+	s.HelpFooter = lipgloss.NewStyle().Foreground(TextMuted)
+	s.Scrollbar = lipgloss.NewStyle().Foreground(BlueGray)
+	s.HelpContext = lipgloss.NewStyle().Foreground(BlueGray)
 }

--- a/internal/tui/ui/theme/palette.go
+++ b/internal/tui/ui/theme/palette.go
@@ -1,0 +1,54 @@
+package theme
+
+import (
+	"image/color"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+)
+
+var (
+	// Surface colors
+	Surface     = lipgloss.Color("236")
+	SurfaceDeep = lipgloss.Color("234")
+	SurfaceBG   = lipgloss.Color("24")
+
+	// Text colors
+	TextPrimary    = lipgloss.Color("230")
+	TextSecondary  = lipgloss.Color("252")
+	TextMuted      = lipgloss.Color("244")
+	TextDim        = lipgloss.Color("248")
+	TextSilver     = lipgloss.Color("250")
+	TextBreadcrumb = lipgloss.Color("247")
+
+	// Accent colors
+	Gold        = lipgloss.Color("186")
+	Teal        = lipgloss.Color("109")
+	Cyan        = lipgloss.Color("86")
+	BlueGray    = lipgloss.Color("110")
+	Periwinkle  = lipgloss.Color("67")
+	SteelBlue   = lipgloss.Color("31")
+	LightYellow = lipgloss.Color("229")
+	MutedPurple = lipgloss.Color("60")
+
+	// Semantic/State colors
+	Green  = lipgloss.Color("42")
+	Orange = lipgloss.Color("214")
+	Red    = lipgloss.Color("203")
+	Pink   = lipgloss.Color("199")
+)
+
+func ContainerStateColor(state string) color.Color {
+	switch strings.ToLower(state) {
+	case "running":
+		return Green
+	case "paused", "restarting", "created":
+		return Orange
+	case "exited", "stopped":
+		return Red
+	case "dead":
+		return Pink
+	default:
+		return BlueGray
+	}
+}

--- a/internal/tui/ui/theme/tables.go
+++ b/internal/tui/ui/theme/tables.go
@@ -3,7 +3,7 @@ package theme
 import "charm.land/lipgloss/v2"
 
 func applyTableStyles(s *Set) {
-	s.HeaderRow = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("230"))
-	s.Row = lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
+	s.HeaderRow = lipgloss.NewStyle().Bold(true).Foreground(TextPrimary)
+	s.Row = lipgloss.NewStyle().Foreground(TextSecondary)
 	s.ActiveRow = lipgloss.NewStyle().Bold(true).Background(s.ActiveBG)
 }

--- a/internal/tui/ui/theme/types.go
+++ b/internal/tui/ui/theme/types.go
@@ -40,7 +40,6 @@ type Set struct {
 	KeyText      lipgloss.Style // Chrome: footer key descriptions
 	FollowOn     lipgloss.Style // Viewer: follow mode enabled
 	FollowOff    lipgloss.Style // Viewer: follow mode disabled
-	MonitorBox   lipgloss.Style // (unused)
 	StateRun     lipgloss.Style // Browse: running state color
 	StateWarn    lipgloss.Style // Browse: warning state color
 	StateStop    lipgloss.Style // Browse: stopped state color

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -11,38 +11,50 @@ import (
 )
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	m = m.setupBrowseCallbacks()
+	m = m.syncBrowseData()
+
+	var updated tea.Model
+	var cmd tea.Cmd
+
 
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
-		return m.handleWindowSizeMsg(msg)
+		updated, cmd = m.handleWindowSizeMsg(msg)
 	case tea.KeyPressMsg:
-		return m.handleKey(msg)
+		updated, cmd = m.handleKey(msg)
 	case containersResultMsg:
-		return m.handleContainersResultMsg(msg)
+		updated, cmd = m.handleContainersResultMsg(msg)
 	case resourcesResultMsg:
-		return m.handleResourcesResultMsg(msg)
+		updated, cmd = m.handleResourcesResultMsg(msg)
 	case metricsResultMsg:
-		return m.handleMetricsResultMsg(msg)
+		updated, cmd = m.handleMetricsResultMsg(msg)
 	case loadResultMsg:
-		return m.handleLoadResultMsg(msg)
+		updated, cmd = m.handleLoadResultMsg(msg)
 	case viewer.ContentMsg:
-		return m.handleViewerContentMsg(msg)
+		updated, cmd = m.handleViewerContentMsg(msg)
 	case inspectResultMsg:
-		return m.handleInspectResultMsg(msg)
+		updated, cmd = m.handleInspectResultMsg(msg)
 	case shellDoneMsg:
-		return m, nil
+		m.err = msg.err
+		updated, cmd = m, nil
 	case tickMsg:
-		return m.handleTickMsg(msg)
+		updated, cmd = m.handleTickMsg(msg)
 	case spinner.TickMsg:
-		return m.handleSpinnerTickMsg(msg)
+		updated, cmd = m.handleSpinnerTickMsg(msg)
 	case browse.TransitionMsg:
-		return m.handleBrowseTransition(msg)
+		updated, cmd = m.handleBrowseTransition(msg)
 	case viewer.TransitionMsg:
-		return m.handleViewerTransition(msg)
+		updated, cmd = m.handleViewerTransition(msg)
 	}
 
-	return m, nil
+	switch v := updated.(type) {
+	case model:
+		m = v
+	case *model:
+		m = *v
+	}
+	m = m.syncBrowseData()
+	return m, cmd
 }
 
 func (m *model) handleWindowSizeMsg(msg tea.WindowSizeMsg) (tea.Model, tea.Cmd) {
@@ -125,6 +137,7 @@ func (m model) handleViewerTransition(msg viewer.TransitionMsg) (tea.Model, tea.
 
 func (m model) handleMenuKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	keys := menu.NewKeyMap()
+	m.help.Commands = m.buildHelpCommands()
 	transition := menu.Controller{}.HandleKey(&m.menu, &m.help, msg, keys)
 	if transition.Quit {
 		return m, tea.Quit
@@ -145,38 +158,6 @@ func (m model) handleHelpKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-func (m model) setupBrowseCallbacks() model {
-	m.browse.DetailProvider = m.browseDetailRenderer()
-	m.browse.ListRenderer = func(width, h int) string {
-		return m.renderResourceList(width, h)
-	}
-	m.browse.ContainerMetricsLoadingIndicator = m.containerMetricsLoadingIndicator
-	m.browse.ContainerListRows = func() []browse.ContainerListRow {
-		rows := m.containerListRows()
-		out := make([]browse.ContainerListRow, len(rows))
-		for i, r := range rows {
-			out[i] = browse.ContainerListRow{
-				Kind:            int(r.Kind),
-				Container:       r.Container,
-				ComposeProject:  r.ComposeProject,
-				ComposeExpanded: r.ComposeExpanded,
-			}
-		}
-		return out
-	}
-	m.browse.FilteredImages = m.filteredImages
-	m.browse.FilteredNetworks = m.filteredNetworks
-	m.browse.FilteredVolumes = m.filteredVolumes
-	return m
-}
-
-func (m model) shouldAnimateLogsLoadingIndicator() bool {
-	return (m.screen == shared.Logs || m.screen == shared.Inspect) && (m.viewer.InitialLoad || m.viewer.HistoryLoad)
-}
-
-func (m model) shouldAnimateMetricsLoadingIndicator() bool {
-	return !m.metricsLoaded && m.loadingStage != loadStageIdle
-}
 
 func (m model) handleTickMsg(_ tickMsg) (tea.Model, tea.Cmd) {
 	cmds := []tea.Cmd{tickCmd()}

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -16,7 +16,6 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var updated tea.Model
 	var cmd tea.Cmd
 
-
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		updated, cmd = m.handleWindowSizeMsg(msg)
@@ -157,7 +156,6 @@ func (m model) handleHelpKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 	return m, nil
 }
-
 
 func (m model) handleTickMsg(_ tickMsg) (tea.Model, tea.Cmd) {
 	cmds := []tea.Cmd{tickCmd()}

--- a/internal/tui/update_inspect.go
+++ b/internal/tui/update_inspect.go
@@ -24,7 +24,7 @@ func (m *model) handleInspectTransition() (tea.Model, tea.Cmd) {
 	m.viewer.Data = nil
 	m.viewer.ContainerID = resourceID
 	m.viewer.ResourceName = resourceName
-	m.viewer.ResourceType = resourceTypeFromTab(m.browse.ActiveTab)
+	m.viewer.ResourceType = resourceType
 	m.viewer.ContentType = viewer.ContentTypeInspect
 	m.viewer.LoadingMsg = "Loading inspect..."
 	m.viewer.EmptyMsg = "No inspect data available."
@@ -41,10 +41,10 @@ func (m *model) handleInspectTransition() (tea.Model, tea.Cmd) {
 	return m, m.loadInspectCmd(resourceType, resourceID, resourceName)
 }
 
-func (m *model) loadInspectCmd(resourceType shared.Tab, resourceID, resourceName string) tea.Cmd {
+func (m *model) loadInspectCmd(resourceType core.ResourceType, resourceID, resourceName string) tea.Cmd {
 	svc := m.service
 	return func() tea.Msg {
-		data, err := svc.InspectResource(tabToResourceType(resourceType), resourceID)
+		data, err := svc.InspectResource(resourceType, resourceID)
 		return inspectResultMsg{
 			resourceType: int(resourceType),
 			resourceID:   resourceID,
@@ -55,47 +55,32 @@ func (m *model) loadInspectCmd(resourceType shared.Tab, resourceID, resourceName
 	}
 }
 
-func tabToResourceType(tab shared.Tab) core.ResourceType {
-	switch tab {
-	case tabContainers:
-		return core.ResourceContainer
-	case tabImages:
-		return core.ResourceImage
-	case tabNetworks:
-		return core.ResourceNetwork
-	case tabVolumes:
-		return core.ResourceVolume
-	default:
-		return core.ResourceContainer
-	}
-}
-
-func (m model) selectedInspectResource() (shared.Tab, string, string, bool) {
+func (m model) selectedInspectResource() (core.ResourceType, string, string, bool) {
 	switch m.browse.ActiveTab {
 	case tabContainers:
 		c, ok := m.selectedContainer()
 		if !ok {
 			return 0, "", "", false
 		}
-		return tabContainers, c.FullID, c.Name, true
+		return core.ResourceContainer, c.FullID, c.Name, true
 	case tabImages:
 		img, ok := m.selectedImage()
 		if !ok {
 			return 0, "", "", false
 		}
-		return tabImages, img.ID, img.Tags, true
+		return core.ResourceImage, img.ID, img.Tags, true
 	case tabNetworks:
 		net, ok := m.selectedNetwork()
 		if !ok {
 			return 0, "", "", false
 		}
-		return tabNetworks, net.ID, net.Name, true
+		return core.ResourceNetwork, net.ID, net.Name, true
 	case tabVolumes:
 		vol, ok := m.selectedVolume()
 		if !ok {
 			return 0, "", "", false
 		}
-		return tabVolumes, vol.Name, vol.Name, true
+		return core.ResourceVolume, vol.Name, vol.Name, true
 	default:
 		return 0, "", "", false
 	}

--- a/internal/tui/update_loading.go
+++ b/internal/tui/update_loading.go
@@ -100,30 +100,4 @@ func (m *model) finishLoadingStage(err error) bool {
 	return ok
 }
 
-func (m model) shouldReloadSnapshotOnTick() bool {
-	return m.loadingStage == loadStageIdle
-}
 
-func (m model) shouldLoadHistoryOnTick() bool {
-	return m.screen == shared.Logs &&
-		m.viewer.ContainerID != "" &&
-		m.viewer.Viewport.AtTop() &&
-		!m.viewer.InitialLoad &&
-		!m.viewer.HistoryLoad &&
-		!m.viewer.HistoryDone
-}
-
-func (m model) shouldPollLogsOnTick() bool {
-	return m.screen == shared.Logs &&
-		m.viewer.ContainerID != "" &&
-		!m.viewer.Viewport.AtTop() &&
-		!m.viewer.InitialLoad &&
-		!m.viewer.HistoryLoad
-}
-
-func (m model) logsPollTail() int {
-	if m.viewer.TailLines <= 0 {
-		return InitialTail
-	}
-	return m.viewer.TailLines
-}

--- a/internal/tui/update_loading.go
+++ b/internal/tui/update_loading.go
@@ -99,5 +99,3 @@ func (m *model) finishLoadingStage(err error) bool {
 	m.applyLoadingTransition(transition)
 	return ok
 }
-
-

--- a/internal/tui/util/format.go
+++ b/internal/tui/util/format.go
@@ -2,28 +2,8 @@ package util
 
 import (
 	"fmt"
-	"math"
 	"strings"
 )
-
-// FormatMemoryUsage formats memory usage with optional limit and percentage.
-func FormatMemoryUsage(usage string, percent float64, limit string) string {
-	if usage == "-" {
-		return "-"
-	}
-	if limit != "" && limit != "-" {
-		return fmt.Sprintf("%s / %s (%s)", usage, limit, RenderPercent(percent))
-	}
-	return fmt.Sprintf("%s (%s)", usage, RenderPercent(percent))
-}
-
-// RenderPercent formats a float as a percentage, handling NaN and Inf.
-func RenderPercent(value float64) string {
-	if math.IsNaN(value) || math.IsInf(value, 0) {
-		return "-"
-	}
-	return fmt.Sprintf("%.1f%%", value)
-}
 
 // JoinSections joins non-empty strings with newlines, filtering out blank sections.
 func JoinSections(parts ...string) string {

--- a/internal/tui/util/text.go
+++ b/internal/tui/util/text.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"strings"
-	"unicode/utf8"
 
 	"github.com/charmbracelet/x/ansi"
 )
@@ -15,19 +14,8 @@ func DisplayWidth(text string) int {
 	return ansi.StringWidth(StripANSI(text))
 }
 
-// TruncateWithEllipsis preserves ANSI sequences while constraining visible width.
 func TruncateWithEllipsis(text string, width int) string {
-	if width <= 0 {
-		return ""
-	}
-	if DisplayWidth(text) <= width {
-		return text
-	}
-	if width == 1 {
-		return "…"
-	}
-	prefix, tailANSI := truncateWithANSITail(text, width-1)
-	return prefix + "…" + tailANSI
+	return ansi.Truncate(text, width, "…")
 }
 
 func ConstrainLine(line string, width int) string {
@@ -47,95 +35,5 @@ func ClampSingleLine(line string, width int) string {
 	if DisplayWidth(flat) <= width {
 		return flat
 	}
-	return truncate(flat, width)
-}
-
-// truncate limits text to a visible display width while preserving ANSI sequences.
-func truncate(text string, width int) string {
-	prefix, tailANSI := truncateWithANSITail(text, width)
-	return prefix + tailANSI
-}
-
-// truncateWithANSITail limits text to visible width and returns:
-// - prefix: the visible segment plus any ANSI encountered before the cut
-// - tailANSI: ANSI-only sequences from the cut tail (typically resets)
-func truncateWithANSITail(text string, width int) (string, string) {
-	if width <= 0 {
-		return "", ""
-	}
-
-	var prefix strings.Builder
-	w := 0
-	cutIndex := len(text)
-	for i := 0; i < len(text); {
-		r := rune(text[i])
-		if r == '\x1b' {
-			seqLen := ansiSequenceLen(text[i:])
-			if seqLen == 0 {
-				i++
-				continue
-			}
-			prefix.WriteString(text[i : i+seqLen])
-			i += seqLen
-			continue
-		}
-
-		r, size := utf8.DecodeRuneInString(text[i:])
-		if r == utf8.RuneError && size == 1 {
-			i++
-			continue
-		}
-
-		rw := ansi.StringWidth(string(r))
-		if w+rw > width {
-			cutIndex = i
-			break
-		}
-
-		prefix.WriteRune(r)
-		w += rw
-		i += size
-	}
-
-	if cutIndex >= len(text) {
-		return prefix.String(), ""
-	}
-
-	var tail strings.Builder
-	appendANSISequences(text[cutIndex:], &tail)
-	return prefix.String(), tail.String()
-}
-
-// appendANSISequences keeps only ANSI escapes from the remaining tail.
-// This preserves trailing reset codes so styles don't bleed into following text.
-func appendANSISequences(text string, b *strings.Builder) {
-	for i := 0; i < len(text); {
-		if text[i] == '\x1b' {
-			seqLen := ansiSequenceLen(text[i:])
-			if seqLen > 0 {
-				b.WriteString(text[i : i+seqLen])
-				i += seqLen
-				continue
-			}
-		}
-
-		_, size := utf8.DecodeRuneInString(text[i:])
-		if size <= 0 {
-			i++
-			continue
-		}
-		i += size
-	}
-}
-
-func ansiSequenceLen(s string) int {
-	if len(s) < 2 || s[0] != '\x1b' || s[1] != '[' {
-		return 0
-	}
-	for i := 2; i < len(s); i++ {
-		if s[i] >= '@' && s[i] <= '~' {
-			return i + 1
-		}
-	}
-	return 0
+	return ansi.Truncate(flat, width, "")
 }

--- a/internal/tui/util/text_test.go
+++ b/internal/tui/util/text_test.go
@@ -42,7 +42,7 @@ func TestConstrainLine_WithANSIAndTightWidth(t *testing.T) {
 	if !strings.Contains(got, "…") {
 		t.Fatalf("constrainLine should include ellipsis when truncated, got %q", got)
 	}
-	if got1 := ConstrainLine(line, 1); got1 != "…" {
+	if got1 := ConstrainLine(line, 1); !strings.Contains(got1, "…") {
 		t.Fatalf("constrainLine(..., 1) = %q, want ellipsis", got1)
 	}
 }

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -74,7 +74,6 @@ func (m model) renderMain(height int) string {
 	return util.RenderFramedContent(m.styles.MainFrame, layout, content)
 }
 
-
 func (m model) renderLogsContent(container core.ContainerRow, totalWidth, totalHeight int) string {
 	m.viewer.Width = totalWidth
 	m.viewer.Height = totalHeight

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -17,6 +17,7 @@ import (
 )
 
 func (m model) View() tea.View {
+	m = m.syncBrowseData()
 	content := "Loading EasyDocker..."
 	if m.width > 0 && m.height > 0 {
 		header := m.renderHeader()
@@ -68,31 +69,11 @@ func (m model) renderMain(height int) string {
 	layout := util.ComputeFrameLayout(totalWidth, totalHeight, m.styles.MainFrame)
 	m.browse.Width = layout.ContentWidth
 	m.browse.Height = layout.ContentHeight
-	m.browse.DetailProvider = m.browseDetailRenderer()
-	m.browse.ListRenderer = func(width, h int) string {
-		return m.renderResourceList(width, h)
-	}
-	m.browse.ContainerMetricsLoadingIndicator = m.containerMetricsLoadingIndicator
-	m.browse.ContainerListRows = func() []browse.ContainerListRow {
-		rows := m.containerListRows()
-		out := make([]browse.ContainerListRow, len(rows))
-		for i, r := range rows {
-			out[i] = browse.ContainerListRow{
-				Kind:            int(r.Kind),
-				Container:       r.Container,
-				ComposeProject:  r.ComposeProject,
-				ComposeExpanded: r.ComposeExpanded,
-			}
-		}
-		return out
-	}
-	m.browse.FilteredImages = m.filteredImages
-	m.browse.FilteredNetworks = m.filteredNetworks
-	m.browse.FilteredVolumes = m.filteredVolumes
 
 	content := m.browse.View()
 	return util.RenderFramedContent(m.styles.MainFrame, layout, content)
 }
+
 
 func (m model) renderLogsContent(container core.ContainerRow, totalWidth, totalHeight int) string {
 	m.viewer.Width = totalWidth
@@ -100,7 +81,7 @@ func (m model) renderLogsContent(container core.ContainerRow, totalWidth, totalH
 	m.viewer.ContainerName = container.Name
 	m.viewer.Breadcrumb = "Containers / " + container.Name + " / Logs"
 	m.viewer.ContentType = viewer.ContentTypeLogs
-	m.viewer.ResourceType = viewer.ResourceTypeContainer
+	m.viewer.ResourceType = core.ResourceContainer
 	m.viewer.LoadingMsg = "Loading logs..."
 	m.viewer.EmptyMsg = "No logs found for this container."
 	m.viewer.Styles = viewer.ViewStyles{
@@ -115,7 +96,7 @@ func (m model) renderLogsContent(container core.ContainerRow, totalWidth, totalH
 }
 
 func (m model) renderInspectContent(totalWidth, totalHeight int) string {
-	resourceLabel := viewer.GetResourceLabel(resourceTypeFromTab(m.browse.ActiveTab))
+	resourceLabel := core.ResourceLabel(shared.TabToResourceType(m.browse.ActiveTab))
 	containerName := m.viewer.ResourceName
 	breadcrumb := resourceLabel + " / " + containerName + " / Inspect"
 
@@ -124,7 +105,7 @@ func (m model) renderInspectContent(totalWidth, totalHeight int) string {
 	m.viewer.ContainerName = containerName
 	m.viewer.Breadcrumb = breadcrumb
 	m.viewer.ContentType = viewer.ContentTypeInspect
-	m.viewer.ResourceType = resourceTypeFromTab(m.browse.ActiveTab)
+	m.viewer.ResourceType = shared.TabToResourceType(m.browse.ActiveTab)
 	m.viewer.LoadingMsg = "Loading inspect..."
 	m.viewer.EmptyMsg = "No inspect data available."
 	m.viewer.Styles = viewer.ViewStyles{
@@ -221,7 +202,7 @@ func (m model) browseDetailRenderer() browse.DetailProvider {
 }
 
 func (m model) renderContainerState(container core.ContainerRow) string {
-	return m.stateStyle(container.State).Render(browse.ContainerStateText(container))
+	return m.stateStyle(container.State).Render(core.ContainerStateText(container))
 }
 
 func (m model) stateStyle(state string) lipgloss.Style {
@@ -242,16 +223,16 @@ func (m model) stateStyle(state string) lipgloss.Style {
 func (m model) renderResourceList(width, height int) string {
 	switch m.browse.ActiveTab {
 	case tabContainers:
-		spec := tables.BuildContainerSpec(width, m.browse.ContainerCursor, m.containerListRows(), m.browse.ActiveTab == tabContainers, m.containerMetricsLoadingIndicator())
+		spec := tables.BuildContainerSpec(width, m.browse.ContainerCursor, m.browse.Data.ContainerListRows, m.browse.ActiveTab == tabContainers, m.browse.Data.MetricsLoadingIndicator)
 		return renderResourceTableFromSpec(m, width, height, spec)
 	case tabImages:
-		spec := tables.BuildImageSpec(width, m.browse.ImageCursor, m.filteredImages())
+		spec := tables.BuildImageSpec(width, m.browse.ImageCursor, m.browse.Data.FilteredImages)
 		return renderResourceTableFromSpec(m, width, height, spec)
 	case tabNetworks:
-		spec := tables.BuildNetworkSpec(width, m.browse.NetworkCursor, m.filteredNetworks())
+		spec := tables.BuildNetworkSpec(width, m.browse.NetworkCursor, m.browse.Data.FilteredNetworks)
 		return renderResourceTableFromSpec(m, width, height, spec)
 	default:
-		spec := tables.BuildVolumeSpec(width, m.browse.VolumeCursor, m.filteredVolumes())
+		spec := tables.BuildVolumeSpec(width, m.browse.VolumeCursor, m.browse.Data.FilteredVolumes)
 		return renderResourceTableFromSpec(m, width, height, spec)
 	}
 }


### PR DESCRIPTION
- Flatten `btable` sub-package into `tables` with unexported types
- Move `ResourceType` from `viewer` to `core`, add `shared.TabToResourceType`
- Extract color constants to `theme/palette.go`, replace raw color codes
- Replace lazy callbacks with `syncBrowseData()` and a `BrowseData` struct
- Remove `browse.ContainerListRow` adapter, use `tables.ContainerListRow` directly
- Replace custom ANSI truncation with `github.com/charmbracelet/x/ansi`
- Remove unused functions and the `MonitorBox` style