### PR TITLE
chore: streamline line filtering logic in viewport and model

### DIFF
--- a/internal/tui/screens/viewer/helpers.go
+++ b/internal/tui/screens/viewer/helpers.go
@@ -285,14 +285,7 @@ func equalLogSlices(a, b []string) bool {
 }
 
 func (vp *Viewport) PrepareContentLines(data []string, query string, wrapWidth int, wrapEnabled bool) []string {
-	sanitized := vp.getSanitizedLines(data)
-
-	var lines []string
-	if vp.ContentType == ContentTypeInspect {
-		lines = FilterJSONLines(sanitized, query)
-	} else {
-		lines = FilterLines(sanitized, query)
-	}
+	lines := vp.FilteredLines()
 
 	if wrapEnabled && wrapWidth > 0 {
 		lines = WrapLines(lines, wrapWidth)

--- a/internal/tui/screens/viewer/helpers.go
+++ b/internal/tui/screens/viewer/helpers.go
@@ -284,7 +284,7 @@ func equalLogSlices(a, b []string) bool {
 	return true
 }
 
-func (vp *Viewport) PrepareContentLines(data []string, query string, wrapWidth int, wrapEnabled bool) []string {
+func (vp *Viewport) PrepareContentLines(wrapWidth int, wrapEnabled bool) []string {
 	lines := vp.FilteredLines()
 
 	if wrapEnabled && wrapWidth > 0 {

--- a/internal/tui/screens/viewer/model.go
+++ b/internal/tui/screens/viewer/model.go
@@ -89,12 +89,7 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 	}
 
 	if key.Matches(msg, keys.ToggleWrap) {
-		var logList []string
-		if m.Vp.ContentType == ContentTypeInspect {
-			logList = FilterJSONLines(m.Vp.Data, m.Vp.Filter.Query)
-		} else {
-			logList = FilterLines(m.Vp.Data, m.Vp.Filter.Query)
-		}
+		logList := m.Vp.FilteredLines()
 		currentStart, _ := VisibleContentRange(m.Vp, logList)
 		m.Vp.SetWrapLines(!m.Vp.WrapLines)
 		m.Vp.SyncFromData(m.VisibleWidth(), m.VisibleRows())
@@ -194,12 +189,7 @@ func (m Model) loadingIndicator() string {
 }
 
 func (m Model) lineCountInfo() *LineCountInfo {
-	var logList []string
-	if m.Vp.ContentType == ContentTypeInspect {
-		logList = FilterJSONLines(m.Vp.Data, m.Vp.Filter.Query)
-	} else {
-		logList = FilterLines(m.Vp.Data, m.Vp.Filter.Query)
-	}
+	logList := m.Vp.FilteredLines()
 	start, end := VisibleContentRange(m.Vp, logList)
 	return &LineCountInfo{Total: len(logList), Start: start + 1, End: max(start+1, end)}
 }

--- a/internal/tui/screens/viewer/view.go
+++ b/internal/tui/screens/viewer/view.go
@@ -127,12 +127,7 @@ func renderPanel(vm ViewModel, width, height int) string {
 		return strings.Join(util.ClipAndPadLines([]string{renderLoadingLine(vm.Styles.Muted, contentWidth, vm.LoadingIndicator, loadingMsg)}, height, ""), "\n")
 	}
 
-	var filtered []string
-	if vm.ContentType == ContentTypeInspect {
-		filtered = FilterJSONLines(vm.Vp.Data, vm.Vp.Filter.Query)
-	} else {
-		filtered = FilterLines(vm.Vp.Data, vm.Vp.Filter.Query)
-	}
+	filtered := vm.Vp.FilteredLines()
 	if len(filtered) == 0 {
 		empty := vm.EmptyMessage
 		if empty == "" {

--- a/internal/tui/screens/viewer/viewport.go
+++ b/internal/tui/screens/viewer/viewport.go
@@ -91,6 +91,14 @@ func (vp *Viewport) getSanitizedLines(raw []string) []string {
 	return vp.sanitizedLines
 }
 
+func (vp *Viewport) FilteredLines() []string {
+	sanitized := vp.getSanitizedLines(vp.Data)
+	if vp.ContentType == ContentTypeInspect {
+		return FilterJSONLines(sanitized, vp.Filter.Query)
+	}
+	return FilterLines(sanitized, vp.Filter.Query)
+}
+
 func (vp *Viewport) ClearCache() {
 	vp.rawLines = nil
 	vp.sanitizedLines = nil

--- a/internal/tui/screens/viewer/viewport.go
+++ b/internal/tui/screens/viewer/viewport.go
@@ -111,6 +111,6 @@ func (vp *Viewport) SyncFromData(visibleWidth, visibleRows int) {
 		vp.SyncViewport(nil, visibleWidth, visibleRows)
 		return
 	}
-	lines := vp.PrepareContentLines(vp.Data, vp.Filter.Query, visibleWidth, vp.WrapLines)
+	lines := vp.PrepareContentLines(visibleWidth, vp.WrapLines)
 	vp.SyncViewport(lines, visibleWidth, visibleRows)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized content filtering in the viewer so Logs and Inspect views use a single filtered source for display.
  * Streamlined line-wrapping behavior when toggling wrap; visible row counts and offsets are computed from the unified filtered set.
  * No intended user-facing behavior changes; display should be more consistent and reliable across viewer modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->