### PR TITLE
chore: enhance JSON filtering to show entire parent structure in results

### DIFF
--- a/internal/tui/screens/viewer/helpers.go
+++ b/internal/tui/screens/viewer/helpers.go
@@ -98,6 +98,12 @@ func isJSONKey(line string) bool {
 	return !isJSONCloser(line) && strings.Contains(line, "\": ")
 }
 
+func isBlockOpener(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	trimmed = strings.TrimSuffix(trimmed, ",")
+	return strings.HasSuffix(trimmed, "{") || strings.HasSuffix(trimmed, "[")
+}
+
 func findJSONParent(lines []string, idx int) int {
 	level := jsonIndentLevel(lines[idx])
 	if level <= 0 {
@@ -116,6 +122,9 @@ func findJSONParent(lines []string, idx int) int {
 }
 
 func findJSONCloser(lines []string, idx int) int {
+	if !isBlockOpener(lines[idx]) {
+		return -1
+	}
 	level := jsonIndentLevel(lines[idx])
 	for j := idx + 1; j < len(lines); j++ {
 		if jsonIndentLevel(lines[j]) == level && isJSONCloser(lines[j]) {

--- a/internal/tui/screens/viewer/helpers.go
+++ b/internal/tui/screens/viewer/helpers.go
@@ -94,61 +94,106 @@ func isJSONCloser(line string) bool {
 	return trimmed == "}" || trimmed == "}," || trimmed == "]" || trimmed == "],"
 }
 
+func isJSONKey(line string) bool {
+	return !isJSONCloser(line) && strings.Contains(line, "\": ")
+}
+
+func findJSONParent(lines []string, idx int) int {
+	level := jsonIndentLevel(lines[idx])
+	if level <= 0 {
+		return -1
+	}
+	if level == 1 {
+		return 0
+	}
+	for k := idx - 1; k >= 0; k-- {
+		l := jsonIndentLevel(lines[k])
+		if l < level && (l == 0 || isJSONKey(lines[k])) {
+			return k
+		}
+	}
+	return 0
+}
+
+func findJSONCloser(lines []string, idx int) int {
+	level := jsonIndentLevel(lines[idx])
+	for j := idx + 1; j < len(lines); j++ {
+		if jsonIndentLevel(lines[j]) == level && isJSONCloser(lines[j]) {
+			return j
+		}
+	}
+	return -1
+}
+
+func buildAncestryPath(lines []string, matchIdx int) []int {
+	path := []int{matchIdx}
+	for {
+		parent := findJSONParent(lines, path[0])
+		if parent < 0 || parent == path[0] {
+			break
+		}
+		path = append([]int{parent}, path...)
+		if jsonIndentLevel(lines[parent]) == 0 {
+			break
+		}
+	}
+	return path
+}
+
 func FilterJSONLines(lines []string, query string) []string {
 	if query == "" || strings.TrimSpace(query) == "" {
 		return lines
 	}
 
-	type block struct{ start, end int }
-	blocks := make([]block, 0)
+	lineSet := make(map[int]bool)
 
 	for i, line := range lines {
 		if !strings.Contains(line, query) {
 			continue
 		}
 
-		matchLevel := jsonIndentLevel(line)
-		end := i + 1
-		for j := i + 1; j < len(lines); j++ {
-			level := jsonIndentLevel(lines[j])
-			if level < matchLevel {
-				end = j
-				break
-			}
-			if level == matchLevel && !isJSONCloser(lines[j]) {
-				end = j
-				break
-			}
-			end = j + 1
+		path := buildAncestryPath(lines, i)
+		if len(path) == 0 {
+			continue
 		}
 
-		blocks = append(blocks, block{i, end})
+		closers := make([]int, len(path))
+		for p, idx := range path {
+			closers[p] = findJSONCloser(lines, idx)
+		}
+
+		for _, idx := range path {
+			lineSet[idx] = true
+		}
+
+		matchIdx := path[len(path)-1]
+		matchCloser := closers[len(closers)-1]
+		if matchCloser > matchIdx+1 {
+			for j := matchIdx + 1; j < matchCloser; j++ {
+				lineSet[j] = true
+			}
+		}
+
+		for p := len(path) - 1; p >= 0; p-- {
+			if closers[p] >= 0 {
+				lineSet[closers[p]] = true
+			}
+		}
 	}
 
-	if len(blocks) == 0 {
+	if len(lineSet) == 0 {
 		return nil
 	}
 
-	sort.Slice(blocks, func(i, j int) bool {
-		return blocks[i].start < blocks[j].start
-	})
-
-	merged := make([]block, 1, len(blocks))
-	merged[0] = blocks[0]
-	for _, b := range blocks[1:] {
-		last := &merged[len(merged)-1]
-		if b.start <= last.end {
-			if b.end > last.end {
-				last.end = b.end
-			}
-		} else {
-			merged = append(merged, b)
-		}
+	indices := make([]int, 0, len(lineSet))
+	for idx := range lineSet {
+		indices = append(indices, idx)
 	}
+	sort.Ints(indices)
 
-	result := make([]string, 0, len(lines))
-	for _, b := range merged {
-		result = append(result, lines[b.start:b.end]...)
+	result := make([]string, len(indices))
+	for i, idx := range indices {
+		result[i] = lines[idx]
 	}
 	return result
 }

--- a/internal/tui/screens/viewer/helpers.go
+++ b/internal/tui/screens/viewer/helpers.go
@@ -162,9 +162,6 @@ func FilterJSONLines(lines []string, query string) []string {
 		}
 
 		path := buildAncestryPath(lines, i)
-		if len(path) == 0 {
-			continue
-		}
 
 		closers := make([]int, len(path))
 		for p, idx := range path {

--- a/internal/tui/screens/viewer/viewer_test.go
+++ b/internal/tui/screens/viewer/viewer_test.go
@@ -149,10 +149,14 @@ func TestFilterJSONLines(t *testing.T) {
 			lines: inspectJSON,
 			query: "Env",
 			expected: []string{
+				`{`,
+				`  "Config": {`,
 				`    "Env": [`,
 				`      "PATH=/usr/bin:/bin",`,
 				`      "HOME=/root"`,
 				`    ],`,
+				`  },`,
+				`}`,
 			},
 		},
 		{
@@ -160,7 +164,13 @@ func TestFilterJSONLines(t *testing.T) {
 			lines: inspectJSON,
 			query: "/root",
 			expected: []string{
+				`{`,
+				`  "Config": {`,
+				`    "Env": [`,
 				`      "HOME=/root"`,
+				`    ],`,
+				`  },`,
+				`}`,
 			},
 		},
 		{
@@ -168,7 +178,11 @@ func TestFilterJSONLines(t *testing.T) {
 			lines: inspectJSON,
 			query: "Cmd",
 			expected: []string{
+				`{`,
+				`  "Config": {`,
 				`    "Cmd": null`,
+				`  },`,
+				`}`,
 			},
 		},
 		{
@@ -176,6 +190,7 @@ func TestFilterJSONLines(t *testing.T) {
 			lines: inspectJSON,
 			query: "Config",
 			expected: []string{
+				`{`,
 				`  "Config": {`,
 				`    "Env": [`,
 				`      "PATH=/usr/bin:/bin",`,
@@ -183,6 +198,7 @@ func TestFilterJSONLines(t *testing.T) {
 				`    ],`,
 				`    "Cmd": null`,
 				`  },`,
+				`}`,
 			},
 		},
 		{
@@ -202,7 +218,13 @@ func TestFilterJSONLines(t *testing.T) {
 			lines: inspectJSON,
 			query: "PATH",
 			expected: []string{
+				`{`,
+				`  "Config": {`,
+				`    "Env": [`,
 				`      "PATH=/usr/bin:/bin",`,
+				`    ],`,
+				`  },`,
+				`}`,
 			},
 		},
 		{
@@ -217,9 +239,11 @@ func TestFilterJSONLines(t *testing.T) {
 			},
 			query: "A",
 			expected: []string{
+				`{`,
 				`  "A": {`,
 				`    "B": 1`,
 				`  },`,
+				`}`,
 			},
 		},
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced JSON filtering so matched keys/values include the full enclosing JSON context, such as relevant parent structures and the correct closing braces.

* **Tests**
  * Updated JSON filtering test cases to expect larger, correctly bounded JSON blocks for matched and overlapping/nested selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->