### PR TITLE
fix: adjust container count in image details

### DIFF
--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"io"
+	"strings"
 	"sync"
 	"time"
 )
@@ -176,6 +177,7 @@ func (s *Service) LoadSnapshot(ctx context.Context) (Snapshot, error) {
 
 	resources.Containers = containers
 
+	resources.Images = ApplyImageContainerCounts(resources.Images, containers)
 	resources.Networks = ApplyNetworkEndpointCounts(resources.Networks, containers)
 
 	if resourcesErr == nil {
@@ -196,6 +198,20 @@ func (s *Service) LoadSnapshot(ctx context.Context) (Snapshot, error) {
 
 func (s *Service) InspectResource(ctx context.Context, rt ResourceType, id string) ([]string, error) {
 	return s.repo.InspectResource(ctx, rt, id)
+}
+
+func ApplyImageContainerCounts(images []ImageRow, containers []ContainerRow) []ImageRow {
+	counts := make(map[string]int)
+	for _, c := range containers {
+		imageID := strings.TrimPrefix(c.ImageID, "sha256:")
+		if len(imageID) >= 12 {
+			counts[imageID[:12]]++
+		}
+	}
+	for i := range images {
+		images[i].Containers = int64(counts[images[i].ID])
+	}
+	return images
 }
 
 func ApplyNetworkEndpointCounts(networks []NetworkRow, containers []ContainerRow) []NetworkRow {

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -66,6 +66,7 @@ type ContainerRow struct {
 	ComposeWorkingDir  string
 	ComposeConfigFiles string
 	Image              string
+	ImageID            string
 	State              ContainerState
 	Status             string
 	Ports              string

--- a/internal/docker/mapper.go
+++ b/internal/docker/mapper.go
@@ -38,6 +38,7 @@ func mapContainerRow(item types.Container) core.ContainerRow {
 		ComposeWorkingDir:  strings.TrimSpace(item.Labels["com.docker.compose.project.working_dir"]),
 		ComposeConfigFiles: strings.TrimSpace(item.Labels["com.docker.compose.project.config_files"]),
 		Image:              item.Image,
+		ImageID:            item.ImageID,
 		State:              core.ContainerState(item.State),
 		Status:             item.Status,
 		Ports:              formatPorts(item.Ports),

--- a/internal/tui/update_loading.go
+++ b/internal/tui/update_loading.go
@@ -29,7 +29,7 @@ func (m *model) handleResourcesResultMsg(msg resourcesResultMsg) (tea.Model, tea
 		return m, nil
 	}
 
-	m.browse.Snapshot.Images = msg.snapshot.Images
+	m.browse.Snapshot.Images = core.ApplyImageContainerCounts(msg.snapshot.Images, m.browse.Snapshot.Containers)
 	m.browse.Snapshot.Volumes = msg.snapshot.Volumes
 	m.browse.Snapshot.TotalLimit = msg.snapshot.TotalLimit
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal tracking of container-to-image associations by extending container data structures and updating the snapshot loading process to calculate and store container counts per image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->