### PR TITLE
chore: extract shared viewer initialization into initViewer helper

### DIFF
--- a/internal/tui/logs.go
+++ b/internal/tui/logs.go
@@ -16,43 +16,12 @@ const (
 )
 
 func (m *model) enterLogsMode(container core.ContainerRow) tea.Cmd {
-	m.pushScreen(m.screen)
-	m.screen = shared.LogViewer
-	m.viewer.Width = m.width
-	m.viewer.Height = max(1, m.height-4)
-	m.viewer.ContainerID = container.FullID
-	m.viewer.Logs.SessionID++
-	m.viewer.Logs.TailLines = InitialTail
-	m.viewer.Vp.InitialLoad = true
+	m.initViewer(shared.LogViewer, viewer.ContentTypeLogs, core.ResourceContainer,
+		container.FullID, container.Name, "Loading logs...", "No logs found for this container.")
 	m.viewer.Vp.Follow = true
-	m.viewer.Vp.Data = nil
-	m.viewer.Logs.HistoryLoad = false
-	m.viewer.Logs.HistoryDone = false
-	m.viewer.Logs.HistoryBaseLen = 0
-	m.viewer.Logs.HistoryAppendedDuringLoad = 0
-	m.viewer.Logs.HistoryNoProgressCount = 0
-	m.viewer.Vp.SetXOffset(0)
-	m.viewer.Vp.Filter.Active = false
-	m.viewer.Vp.Filter.Query = ""
-	m.viewer.Vp.Filter.Input.SetValue("")
-	m.viewer.Vp.ContentType = viewer.ContentTypeLogs
-	m.viewer.ResourceType = core.ResourceContainer
-	m.viewer.LoadingMsg = "Loading logs..."
-	m.viewer.EmptyMsg = "No logs found for this container."
-	m.viewer.Breadcrumb = ""
-	m.viewer.ContainerName = container.Name
-	m.viewer.Styles = viewer.Styles{
-		Breadcrumb:   m.styles.Viewer.Breadcrumb,
-		FollowOn:     m.styles.Viewer.FollowOn,
-		FollowOff:    m.styles.Viewer.FollowOff,
-		Muted:        m.styles.Browse.Muted,
-		Divider:      m.styles.Browse.Divider,
-		SubpageFrame: m.styles.Viewer.SubpageFrame,
-		Key:          m.styles.Chrome.Key,
-		KeyText:      m.styles.Chrome.KeyText,
-	}
-	m.err = nil
-	return LoadLogsCmd(m.service, m.viewer.ContainerID, m.viewer.Logs.SessionID, m.viewer.Logs.TailLines, viewer.SourceInitial)
+	m.viewer.Logs = viewer.NewLogsViewer()
+	return LoadLogsCmd(m.service, m.viewer.ContainerID, m.viewer.Logs.SessionID,
+		m.viewer.Logs.TailLines, viewer.SourceInitial)
 }
 
 func LoadLogsCmd(service core.ServiceInterface, containerID string, sessionID, tail int, src viewer.Source) tea.Cmd {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -133,3 +133,39 @@ func (m *model) popScreen() shared.Screen {
 	m.screenStack = m.screenStack[:len(m.screenStack)-1]
 	return s
 }
+
+func (m *model) initViewer(
+	screen shared.Screen,
+	contentType viewer.ContentType,
+	resourceType core.ResourceType,
+	containerID, resourceName, loadingMsg, emptyMsg string,
+) {
+	m.pushScreen(m.screen)
+	m.screen = screen
+	m.viewer.Width = m.width
+	m.viewer.Height = max(1, m.height-4)
+	m.viewer.ContainerID = containerID
+	m.viewer.ResourceType = resourceType
+	m.viewer.ContainerName = resourceName
+	m.viewer.LoadingMsg = loadingMsg
+	m.viewer.EmptyMsg = emptyMsg
+	m.viewer.Breadcrumb = ""
+	m.viewer.Vp.InitialLoad = true
+	m.viewer.Vp.Data = nil
+	m.viewer.Vp.SetXOffset(0)
+	m.viewer.Vp.Filter.Active = false
+	m.viewer.Vp.Filter.Query = ""
+	m.viewer.Vp.Filter.Input.SetValue("")
+	m.viewer.Vp.ContentType = contentType
+	m.viewer.Styles = viewer.Styles{
+		Breadcrumb:   m.styles.Viewer.Breadcrumb,
+		FollowOn:     m.styles.Viewer.FollowOn,
+		FollowOff:    m.styles.Viewer.FollowOff,
+		Muted:        m.styles.Browse.Muted,
+		Divider:      m.styles.Browse.Divider,
+		SubpageFrame: m.styles.Viewer.SubpageFrame,
+		Key:          m.styles.Chrome.Key,
+		KeyText:      m.styles.Chrome.KeyText,
+	}
+	m.err = nil
+}

--- a/internal/tui/update_inspect.go
+++ b/internal/tui/update_inspect.go
@@ -15,33 +15,11 @@ func (m *model) handleInspectTransition() (tea.Model, tea.Cmd) {
 	if !ok {
 		return m, nil
 	}
-	m.pushScreen(m.screen)
-	m.screen = shared.InspectViewer
-	m.viewer.Width = m.width
-	m.viewer.Height = max(1, m.height-4)
+	m.initViewer(shared.InspectViewer, viewer.ContentTypeInspect, resourceType,
+		resourceID, resourceName, "Loading inspect...", "No inspect data available.")
 	m.viewer.Vp.Follow = false
-	m.viewer.Vp.SetXOffset(0)
 	m.viewer.Vp.GotoTop()
-	m.viewer.Vp.InitialLoad = true
-	m.viewer.Vp.Data = nil
-	m.viewer.ContainerID = resourceID
 	m.viewer.Inspect.ResourceName = resourceName
-	m.viewer.ResourceType = resourceType
-	m.viewer.Vp.ContentType = viewer.ContentTypeInspect
-	m.viewer.LoadingMsg = "Loading inspect..."
-	m.viewer.EmptyMsg = "No inspect data available."
-	m.viewer.Breadcrumb = ""
-	m.viewer.ContainerName = resourceName
-	m.viewer.Styles = viewer.Styles{
-		Breadcrumb:   m.styles.Viewer.Breadcrumb,
-		FollowOn:     m.styles.Viewer.FollowOn,
-		FollowOff:    m.styles.Viewer.FollowOff,
-		Muted:        m.styles.Browse.Muted,
-		Divider:      m.styles.Browse.Divider,
-		SubpageFrame: m.styles.Viewer.SubpageFrame,
-		Key:          m.styles.Chrome.Key,
-		KeyText:      m.styles.Chrome.KeyText,
-	}
 	return m, m.loadInspectCmd(resourceType, resourceID, resourceName)
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized viewer initialization logic to reduce code duplication and improve maintainability across logs and inspect features. No user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->