### PR TITLE
fix: adjust visible rows calculation and sync viewport data in render methods

### DIFF
--- a/internal/tui/screens/viewer/model.go
+++ b/internal/tui/screens/viewer/model.go
@@ -209,7 +209,9 @@ func (m Model) VisibleWidth() int {
 }
 
 func (m Model) VisibleRows() int {
-	return VisibleRowsForContent(m.Height)
+	frameHeight := m.Styles.SubpageFrame.GetVerticalFrameSize()
+	contentHeight := max(1, max(1, m.Height)-frameHeight)
+	return VisibleRowsForContent(contentHeight)
 }
 
 func (m *Model) applyHistoryWithMerge(data []string) {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -103,6 +103,7 @@ func (m model) renderLogsContent(container core.ContainerRow, totalWidth, totalH
 		Key:          m.styles.Chrome.Key,
 		KeyText:      m.styles.Chrome.KeyText,
 	}
+	m.viewer.Vp.SyncFromData(m.viewer.VisibleWidth(), m.viewer.VisibleRows())
 	return m.viewer.View()
 }
 
@@ -129,6 +130,7 @@ func (m model) renderInspectContent(totalWidth, totalHeight int) string {
 		Key:          m.styles.Chrome.Key,
 		KeyText:      m.styles.Chrome.KeyText,
 	}
+	m.viewer.Vp.SyncFromData(m.viewer.VisibleWidth(), m.viewer.VisibleRows())
 	return m.viewer.View()
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed content display height calculation in the viewer to properly account for UI frame elements.
  * Fixed viewport synchronization in logs and inspect views to ensure visible content dimensions are correctly reflected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->